### PR TITLE
fixes #96 NewConnPipe can wait indefinitely on peer

### DIFF
--- a/test/survey_test.go
+++ b/test/survey_test.go
@@ -124,7 +124,7 @@ func surveyCases() []TestCase {
 	surv.MsgSize = 8
 	surv.WantTx = 1
 	surv.WantRx = int32(nresp)
-	surv.txdelay = time.Second / 7
+	surv.txdelay = time.Second / 5
 	surv.Synch = true
 	surv.NReply = int(nresp)
 	cases[0] = surv

--- a/transport/connipc_posix.go
+++ b/transport/connipc_posix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -38,10 +38,6 @@ func NewConnPipeIPC(c net.Conn, proto ProtocolInfo, options map[string]interface
 		p.options[n] = v
 	}
 	p.maxrx = p.options[mangos.OptionMaxRecvSize].(int)
-
-	if err := p.handshake(); err != nil {
-		return nil, err
-	}
 
 	return p, nil
 }

--- a/transport/connipc_windows.go
+++ b/transport/connipc_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -38,10 +38,6 @@ func NewConnPipeIPC(c net.Conn, proto ProtocolInfo, options map[string]interface
 		p.options[n] = v
 	}
 	p.maxrx = p.options[mangos.OptionMaxRecvSize].(int)
-
-	if err := p.handshake(); err != nil {
-		return nil, err
-	}
 
 	return p, nil
 }

--- a/transport/handshaker.go
+++ b/transport/handshaker.go
@@ -1,0 +1,37 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+// Handshaker is used to support dealing with asynchronous
+// handshaking used for some transports.  This allows the
+// initial handshaking to be done in the background, without
+// stalling the server's accept queue.  This is important to
+// ensure that a slow remote peer cannot bog down the server
+// or effect a denial-of-service for new connections.
+type Handshaker interface {
+	// Start injects a pipe into the handshaker.  The
+	// handshaking is done asynchronously on a Go routine.
+	Start(Pipe) error
+
+	// Waits for until a pipe has completely finished the
+	// handshaking and returns it.
+	Wait() (Pipe, error)
+
+	// Close is used to close the handshaker.  Any existing
+	// negotiations will be canceled, and the underlying
+	// transport sockets will be closed.  Any new attempts
+	// to start will return mangos.ErrClosed.
+	Close() error
+}

--- a/transport/ipc/ipc_test.go
+++ b/transport/ipc/ipc_test.go
@@ -21,7 +21,7 @@ import (
 	"nanomsg.org/go/mangos/v2/test"
 )
 
-var tt = test.NewTranTest(Transport, "ipc://test1234")
+var tt = test.NewTranTest(Transport, "ipc:///tmp/test1234")
 
 func TestIpcListenAndAccept(t *testing.T) {
 	switch runtime.GOOS {


### PR DESCRIPTION
This fixes an important security and reliability concern -- a some of the early negotiation logic was on a synchronous path for dialing, and this could allow a bad peer to either slow or completely stall out any new connections from being established.

The Dialer side is still synchronous, by necessity, as it only opens a single connection at a time.