### PR TITLE
Move star protocol tests into star package.

### DIFF
--- a/internal/test/addrs.go
+++ b/internal/test/addrs.go
@@ -1,0 +1,63 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+)
+
+var currPort uint32
+
+func init() {
+	currPort = uint32(time.Now().UnixNano()%20000 + 20000)
+}
+
+// NextPort returns the next port, incrementing by one.
+func NextPort() uint32 {
+	return atomic.AddUint32(&currPort, 1)
+}
+
+// AddrTestIPC returns a test IPC address.  It will be in the current
+// directory.
+func AddrTestIPC() string {
+	return (fmt.Sprintf("ipc://mangostest%d", NextPort()))
+}
+
+// AddrTestWSS returns a websocket over TLS address.
+func AddrTestWSS() string {
+	return (fmt.Sprintf("wss://127.0.0.1:%d/", NextPort()))
+}
+
+// AddrTestWS returns a websocket address.
+func AddrTestWS() string {
+	return (fmt.Sprintf("ws://127.0.0.1:%d/", NextPort()))
+}
+
+// AddrTestTCP returns a TCP address.
+func AddrTestTCP() string {
+	return (fmt.Sprintf("tcp://127.0.0.1:%d", NextPort()))
+}
+
+// AddrTestTLS returns a TLS over TCP address.
+func AddrTestTLS() string {
+	return (fmt.Sprintf("tls+tcp://127.0.0.1:%d", NextPort()))
+}
+
+// AddrTestInp returns an inproc address.
+func AddrTestInp() string {
+	return (fmt.Sprintf("inproc://test_%d", NextPort()))
+}

--- a/internal/test/must.go
+++ b/internal/test/must.go
@@ -1,0 +1,64 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES O R CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"reflect"
+	"testing"
+)
+
+// MustSucceed verifies that that the supplied error is nil.
+// If it is not nil, we call t.Fatalf() to fail the test immediately.
+func MustSucceed(t *testing.T, e error) {
+	if e != nil {
+		t.Fatalf("Error is not nil: %v", e)
+	}
+}
+
+// MustFail verifies that the error is not nil.
+// If it is nil, the test is a fatal failure.
+func MustFail(t *testing.T, e error) {
+	if e == nil {
+		t.Fatalf("Error is nil")
+	}
+}
+
+// MustBeTrue verifies that the condition is true.
+func MustBeTrue(t *testing.T, b bool) {
+	if !b {
+		t.Fatalf("Condition is false")
+	}
+}
+
+// MustBeFalse verifies that the condition is true.
+func MustBeFalse(t *testing.T, b bool) {
+	if b {
+		t.Fatalf("Condition is true")
+	}
+}
+
+// MustNotBeNil verifies that the provided value is not nil
+func MustNotBeNil(t *testing.T, v interface{}) {
+	if reflect.ValueOf(v).IsNil() {
+		t.Fatalf("Value is nil")
+	}
+}
+
+// MustBeNil verifies that the provided value is nil
+func MustBeNil(t *testing.T, v interface{}) {
+	if !reflect.ValueOf(v).IsNil() {
+		t.Fatalf("Value is not nil: %v", v)
+	}
+}

--- a/internal/test/raw.go
+++ b/internal/test/raw.go
@@ -1,0 +1,55 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"nanomsg.org/go/mangos/v2"
+)
+
+// VerifyRaw verifies that the socket created is raw, and cannot be changed to cooked.
+func VerifyRaw(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	defer s.Close()
+	val, err := s.GetOption(mangos.OptionRaw)
+	MustSucceed(t, err)
+	if b, ok := val.(bool); ok {
+		MustBeTrue(t, b)
+	} else {
+		t.Fatalf("Not a boolean")
+	}
+
+	err = s.SetOption(mangos.OptionRaw, false)
+	MustFail(t, err)
+}
+
+// VerifyCooked verifies that the socket created is cooked, and cannot be changed to raw.
+func VerifyCooked(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	defer s.Close()
+	val, err := s.GetOption(mangos.OptionRaw)
+	MustSucceed(t, err)
+	if b, ok := val.(bool); ok {
+		MustBeFalse(t, b)
+	} else {
+		t.Fatalf("Not a boolean")
+	}
+
+	err = s.SetOption(mangos.OptionRaw, true)
+	MustFail(t, err)
+}

--- a/internal/test/ttl.go
+++ b/internal/test/ttl.go
@@ -1,0 +1,246 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"nanomsg.org/go/mangos/v2"
+)
+
+// SetTTLZero tests that a given socket fails to set a TTL of zero.
+func SetTTLZero(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	if err != nil {
+		t.Errorf("Failed to make socket: %v", err)
+		return
+	}
+	defer s.Close()
+	err = s.SetOption(mangos.OptionTTL, 0)
+	switch err {
+	case mangos.ErrBadValue: // expected result
+	case nil:
+		t.Errorf("Negative test fail, permitted zero TTL")
+	default:
+		t.Errorf("Negative test fail (0), wrong error %v", err)
+	}
+}
+
+// SetTTLNegative tests that a given socket fails to set a negative TTL.
+func SetTTLNegative(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	if err != nil {
+		t.Errorf("Failed to make socket: %v", err)
+		return
+	}
+	defer s.Close()
+	err = s.SetOption(mangos.OptionTTL, -1)
+	switch err {
+	case mangos.ErrBadValue: // expected result
+	case nil:
+		t.Errorf("Negative test fail, permitted negative TTL")
+	default:
+		t.Errorf("Negative test fail (-1), wrong error %v", err)
+	}
+}
+
+// SetTTLTooBig tests that a given socket fails to set a very large TTL.
+func SetTTLTooBig(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	if err != nil {
+		t.Errorf("Failed to make socket: %v", err)
+		return
+	}
+	defer s.Close()
+	err = s.SetOption(mangos.OptionTTL, 256)
+	switch err {
+	case mangos.ErrBadValue: // expected result
+	case nil:
+		t.Errorf("Negative test fail, permitted too large TTL")
+	default:
+		t.Errorf("Negative test fail (256), wrong error %v", err)
+	}
+}
+
+// SetTTLNotInt tests that a given socket fails to set a non-integer TTL.
+func SetTTLNotInt(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	if err != nil {
+		t.Errorf("Failed to make socket: %v", err)
+		return
+	}
+	defer s.Close()
+	err = s.SetOption(mangos.OptionTTL, "garbage")
+	switch err {
+	case mangos.ErrBadValue: // expected result
+	case nil:
+		t.Errorf("Negative test fail, permitted non-int value")
+	default:
+		t.Errorf("Negative test fail (garbage), wrong error %v", err)
+	}
+}
+
+// SetTTL tests that we can set a valid TTL, and get the same value back.
+func SetTTL(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	if err != nil {
+		t.Errorf("Failed to make socket: %v", err)
+		return
+	}
+	defer s.Close()
+
+	err = s.SetOption(mangos.OptionTTL, 2)
+	if err != nil {
+		t.Errorf("Failed SetOption: %v", err)
+		return
+	}
+
+	v, err := s.GetOption(mangos.OptionTTL)
+	if err != nil {
+		t.Errorf("Failed GetOption: %v", err)
+		return
+	}
+	if val, ok := v.(int); !ok {
+		t.Errorf("Returned value not type int")
+	} else if val != 2 {
+		t.Errorf("Returned value %d not %d", val, 2)
+	}
+}
+
+// TTLDropTest is a generic test for dropping based on TTL expiration.
+// F1 makes the client socket, f2 makes the server socket.
+func TTLDropTest(t *testing.T,
+	cli func() (mangos.Socket, error),
+	srv func() (mangos.Socket, error),
+	rawcli func() (mangos.Socket, error),
+	rawsrv func() (mangos.Socket, error)) {
+
+	nhop := 3
+	clis := make([]mangos.Socket, 0, nhop)
+	srvs := make([]mangos.Socket, 0, nhop)
+	a := AddrTestInp()
+
+	for i := 0; i < nhop; i++ {
+		var fn func() (mangos.Socket, error)
+		if i == nhop-1 {
+			fn = srv
+		} else {
+			fn = rawsrv
+		}
+		s, err := fn()
+		if err != nil {
+			t.Errorf("Failed to make server: %v", err)
+			return
+		}
+		defer s.Close()
+
+		err = s.Listen(a + fmt.Sprintf("HOP%d", i))
+		if err != nil {
+			t.Errorf("Failed listen: %v", err)
+			return
+		}
+
+		srvs = append(srvs, s)
+	}
+
+	for i := 0; i < nhop; i++ {
+		var fn func() (mangos.Socket, error)
+		if i == 0 {
+			fn = cli
+		} else {
+			fn = rawcli
+		}
+		s, err := fn()
+		if err != nil {
+			t.Errorf("Failed to make client: %v", err)
+			return
+		}
+		defer s.Close()
+
+		err = s.Dial(a + fmt.Sprintf("HOP%d", i))
+		if err != nil {
+			t.Errorf("Failed dial: %v", err)
+			return
+		}
+
+		clis = append(clis, s)
+	}
+
+	// Now make the device chain
+	for i := 0; i < nhop-1; i++ {
+		err := mangos.Device(srvs[i], clis[i+1])
+		if err != nil {
+			t.Errorf("Device failed: %v", err)
+			return
+		}
+	}
+
+	// Wait for the various connections to plumb up
+	time.Sleep(time.Millisecond * 100)
+
+	// At this point, we can issue requests on clis[0], and read them from
+	// srvs[nhop-1].
+
+	rq := clis[0]
+	rp := srvs[nhop-1]
+
+	err := rp.SetOption(mangos.OptionRecvDeadline, time.Millisecond*100)
+	if err != nil {
+		t.Errorf("Failed set recv deadline")
+		return
+	}
+
+	t.Logf("Socket for sending is %s", rq.Info().SelfName)
+	if err = rq.Send([]byte("GOOD")); err != nil {
+		t.Errorf("Failed first send: %v", err)
+		return
+	}
+	t.Logf("Socket for receiving is %s", rp.Info().SelfName)
+	v, err := rp.Recv()
+	if err != nil {
+		t.Errorf("Failed first recv: %v", err)
+		return
+	} else if !bytes.Equal(v, []byte("GOOD")) {
+		t.Errorf("Got wrong message: %v", v)
+		return
+	} else {
+		t.Logf("Got good message: %v", v)
+	}
+
+	// Now try setting the option.
+	err = rp.SetOption(mangos.OptionTTL, nhop-1)
+	if err != nil {
+		t.Errorf("Failed set TTL: %v", err)
+		return
+	}
+
+	if err = rq.Send([]byte("DROP")); err != nil {
+		t.Errorf("Failed send drop: %v", err)
+		return
+	}
+
+	v, err = rp.Recv()
+	switch err {
+	case mangos.ErrRecvTimeout: // expected
+		t.Logf("TTL honored")
+	case nil:
+		t.Errorf("Message not dropped: %v", v)
+	default:
+		t.Errorf("Got unexpected error: %v", err)
+	}
+}

--- a/protocol/star/cooked_test.go
+++ b/protocol/star/cooked_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package star
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestStarCooked(t *testing.T) {
+	VerifyCooked(t, NewSocket)
+}

--- a/protocol/star/nonblock_test.go
+++ b/protocol/star/nonblock_test.go
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package star
 
 import (
 	"testing"
 	"time"
 
 	"nanomsg.org/go/mangos/v2"
-	"nanomsg.org/go/mangos/v2/protocol/star"
-	_ "nanomsg.org/go/mangos/v2/transport/tcp"
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
 )
 
-func testStarNonBlock(t *testing.T, addr string) {
+func TestStarNonBlock(t *testing.T) {
 	maxqlen := 2
 
-	rp, err := star.NewSocket()
+	rp, err := NewSocket()
 	MustSucceed(t, err)
 	MustNotBeNil(t, rp)
 	defer rp.Close()
 
 	MustSucceed(t, rp.SetOption(mangos.OptionWriteQLen, maxqlen))
-	MustSucceed(t, rp.Listen(addr))
+	MustSucceed(t, rp.Listen(AddrTestInp()))
 
 	msg := []byte{'A', 'B', 'C'}
 
@@ -42,8 +42,4 @@ func testStarNonBlock(t *testing.T, addr string) {
 	}
 	end := time.Now()
 	MustBeTrue(t, end.Sub(start) < time.Second/10)
-}
-
-func TestStarNonBlockTCP(t *testing.T) {
-	testStarNonBlock(t, AddrTestTCP())
 }

--- a/protocol/star/star_test.go
+++ b/protocol/star/star_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package star
 
 import (
 	"math/rand"
@@ -20,9 +20,8 @@ import (
 	"time"
 
 	"nanomsg.org/go/mangos/v2"
-	"nanomsg.org/go/mangos/v2/protocol/star"
-	"nanomsg.org/go/mangos/v2/protocol/xstar"
-	_ "nanomsg.org/go/mangos/v2/transport/all"
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
 )
 
 type starTester struct {
@@ -99,7 +98,7 @@ func starTestNewServer(t *testing.T, addr string, id int) *starTester {
 	var err error
 	bt := &starTester{id: id, rdoneq: make(chan bool), sdoneq: make(chan bool)}
 
-	if bt.sock, err = star.NewSocket(); err != nil {
+	if bt.sock, err = NewSocket(); err != nil {
 		t.Errorf("Failed getting server %d socket: %v", id, err)
 		return nil
 	}
@@ -115,7 +114,7 @@ func starTestNewClient(t *testing.T, addr string, id int) *starTester {
 	var err error
 	bt := &starTester{id: id, rdoneq: make(chan bool), sdoneq: make(chan bool)}
 
-	if bt.sock, err = star.NewSocket(); err != nil {
+	if bt.sock, err = NewSocket(); err != nil {
 		t.Errorf("Failed getting client %d socket: %v", id, err)
 		return nil
 	}
@@ -138,8 +137,7 @@ func starTestCleanup(t *testing.T, bts []*starTester) {
 }
 
 func TestStar(t *testing.T) {
-	addr := "tcp://127.0.0.1:3538"
-
+	addr := AddrTestInp()
 	num := 5
 	pkts := 7
 	bts := make([]*starTester, num)
@@ -197,28 +195,4 @@ func TestStar(t *testing.T) {
 		}
 	}
 	t.Logf("All pass")
-}
-
-func TestStarTTLZero(t *testing.T) {
-	SetTTLZero(t, xstar.NewSocket)
-}
-
-func TestStarTTLNegative(t *testing.T) {
-	SetTTLNegative(t, xstar.NewSocket)
-}
-
-func TestStarTTLTooBig(t *testing.T) {
-	SetTTLTooBig(t, xstar.NewSocket)
-}
-
-func TestStarTTLNotInt(t *testing.T) {
-	SetTTLNotInt(t, xstar.NewSocket)
-}
-
-func TestStarTTLSet(t *testing.T) {
-	SetTTL(t, xstar.NewSocket)
-}
-
-func TestStarTTLDrop(t *testing.T) {
-	TTLDropTest(t, star.NewSocket, star.NewSocket, xstar.NewSocket, xstar.NewSocket)
 }

--- a/protocol/star/ttl_test.go
+++ b/protocol/star/ttl_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package star
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	"nanomsg.org/go/mangos/v2/protocol/xstar"
+	_ "nanomsg.org/go/mangos/v2/transport/all"
+)
+
+func TestStarTTLZero(t *testing.T) {
+	SetTTLZero(t, NewSocket)
+}
+
+func TestStarTTLNegative(t *testing.T) {
+	SetTTLNegative(t, NewSocket)
+}
+
+func TestStarTTLTooBig(t *testing.T) {
+	SetTTLTooBig(t, NewSocket)
+}
+
+func TestStarTTLNotInt(t *testing.T) {
+	SetTTLNotInt(t, NewSocket)
+}
+
+func TestStarTTLSet(t *testing.T) {
+	SetTTL(t, NewSocket)
+}
+
+func TestStarTTLDrop(t *testing.T) {
+	TTLDropTest(t, NewSocket, NewSocket, xstar.NewSocket, xstar.NewSocket)
+}

--- a/protocol/xstar/raw_test.go
+++ b/protocol/xstar/raw_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xstar
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestXStarRaw(t *testing.T) {
+	VerifyRaw(t, NewSocket)
+}

--- a/protocol/xstar/ttl_test.go
+++ b/protocol/xstar/ttl_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xstar
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/all"
+)
+
+func TestXStarTTLZero(t *testing.T) {
+	SetTTLZero(t, NewSocket)
+}
+
+func TestXStarTTLNegative(t *testing.T) {
+	SetTTLNegative(t, NewSocket)
+}
+
+func TestXStarTTLTooBig(t *testing.T) {
+	SetTTLTooBig(t, NewSocket)
+}
+
+func TestXStarTTLNotInt(t *testing.T) {
+	SetTTLNotInt(t, NewSocket)
+}
+
+func TestXStarTTLSet(t *testing.T) {
+	SetTTL(t, NewSocket)
+}


### PR DESCRIPTION
This is the start of various test refactoring.  It also introduces
a utility internal test package, and adds some more tests that we
really want.  Finally by running the star tests over inproc we are
less likely to get problems from TCP or other networks being slow
in CI/CD situations.