### PR TITLE
Reorganization of surveyor tests part 1.

### DIFF
--- a/internal/test/raw.go
+++ b/internal/test/raw.go
@@ -35,6 +35,8 @@ func VerifyRaw(t *testing.T, f func() (mangos.Socket, error)) {
 
 	err = s.SetOption(mangos.OptionRaw, false)
 	MustFail(t, err)
+	err = s.SetOption(mangos.OptionRaw, 1)
+	MustFail(t, err)
 }
 
 // VerifyCooked verifies that the socket created is cooked, and cannot be changed to raw.
@@ -51,5 +53,7 @@ func VerifyCooked(t *testing.T, f func() (mangos.Socket, error)) {
 	}
 
 	err = s.SetOption(mangos.OptionRaw, true)
+	MustFail(t, err)
+	err = s.SetOption(mangos.OptionRaw, 0)
 	MustFail(t, err)
 }

--- a/protocol/respondent/cooked_test.go
+++ b/protocol/respondent/cooked_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package respondent
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestRespondentCooked(t *testing.T) {
+	VerifyCooked(t, NewSocket)
+}

--- a/protocol/respondent/ttl_test.go
+++ b/protocol/respondent/ttl_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package respondent
+
+import (
+	"nanomsg.org/go/mangos/v2/protocol/surveyor"
+	"nanomsg.org/go/mangos/v2/protocol/xrespondent"
+	"nanomsg.org/go/mangos/v2/protocol/xsurveyor"
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/all"
+)
+
+func TestRespondentTTLZero(t *testing.T) {
+	SetTTLZero(t, NewSocket)
+}
+
+func TestRespondentTTLNegative(t *testing.T) {
+	SetTTLNegative(t, NewSocket)
+}
+
+func TestRespondentTTLTooBig(t *testing.T) {
+	SetTTLTooBig(t, NewSocket)
+}
+
+func TestRespondentTTLNotInt(t *testing.T) {
+	SetTTLNotInt(t, NewSocket)
+}
+
+func TestRespondentTTLSet(t *testing.T) {
+	SetTTL(t, NewSocket)
+}
+
+func TestRespondentTTLDrop(t *testing.T) {
+	TTLDropTest(t, surveyor.NewSocket, NewSocket, xsurveyor.NewSocket, xrespondent.NewSocket)
+}

--- a/protocol/surveyor/cooked_test.go
+++ b/protocol/surveyor/cooked_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package surveyor
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestSurveyorCooked(t *testing.T) {
+	VerifyCooked(t, NewSocket)
+}

--- a/protocol/surveyor/nonblock_test.go
+++ b/protocol/surveyor/nonblock_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -12,27 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package test
+package surveyor
 
 import (
 	"testing"
 	"time"
 
 	"nanomsg.org/go/mangos/v2"
-	"nanomsg.org/go/mangos/v2/protocol/surveyor"
-	_ "nanomsg.org/go/mangos/v2/transport/tcp"
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
 )
 
-func testSurvNonBlock(t *testing.T, addr string) {
+func TestSurveyorNonBlock(t *testing.T) {
 	maxqlen := 2
 
-	rp, err := surveyor.NewSocket()
+	rp, err := NewSocket()
 	MustSucceed(t, err)
 	MustNotBeNil(t, rp)
 	defer rp.Close()
 
 	MustSucceed(t, rp.SetOption(mangos.OptionWriteQLen, maxqlen))
-	MustSucceed(t, rp.Listen(addr))
+	MustSucceed(t, rp.Listen(AddrTestInp()))
 
 	msg := []byte{'A', 'B', 'C'}
 	start := time.Now()
@@ -41,8 +41,4 @@ func testSurvNonBlock(t *testing.T, addr string) {
 	}
 	end := time.Now()
 	MustBeTrue(t, end.Sub(start) < time.Second/10)
-}
-
-func TestSurveyorNonBlockTCP(t *testing.T) {
-	testSurvNonBlock(t, AddrTestTCP())
 }

--- a/protocol/xrespondent/raw_test.go
+++ b/protocol/xrespondent/raw_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xrespondent
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestXRespondentRaw(t *testing.T) {
+	VerifyRaw(t, NewSocket)
+}

--- a/protocol/xrespondent/xrespondent.go
+++ b/protocol/xrespondent/xrespondent.go
@@ -244,6 +244,7 @@ func (s *socket) SetOption(name string, value interface{}) error {
 			return nil
 		}
 		return protocol.ErrBadValue
+
 	case protocol.OptionSendDeadline:
 		if v, ok := value.(time.Duration); ok {
 			s.Lock()
@@ -279,8 +280,6 @@ func (s *socket) SetOption(name string, value interface{}) error {
 			s.recvq = newchan
 			s.Unlock()
 		}
-		// We don't support these
-		// case OptionLinger:
 	}
 
 	return protocol.ErrBadOption

--- a/protocol/xsurveyor/raw_test.go
+++ b/protocol/xsurveyor/raw_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xsurveyor
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+)
+
+func TestXSurveyorRaw(t *testing.T) {
+	VerifyRaw(t, NewSocket)
+}

--- a/test/survey_test.go
+++ b/test/survey_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -22,8 +22,6 @@ import (
 	"nanomsg.org/go/mangos/v2"
 	"nanomsg.org/go/mangos/v2/protocol/respondent"
 	"nanomsg.org/go/mangos/v2/protocol/surveyor"
-	"nanomsg.org/go/mangos/v2/protocol/xrespondent"
-	"nanomsg.org/go/mangos/v2/protocol/xsurveyor"
 )
 
 type surveyTest struct {
@@ -141,51 +139,6 @@ func surveyCases() []TestCase {
 	return cases
 }
 
-func TestSurveyTCP(t *testing.T) {
-	RunTestsTCP(t, surveyCases())
-}
-
-func TestSurveyIPC(t *testing.T) {
-	RunTestsIPC(t, surveyCases())
-}
-
 func TestSurveyInp(t *testing.T) {
 	RunTestsInp(t, surveyCases())
-}
-
-func TestSurveyTLS(t *testing.T) {
-	RunTestsTLS(t, surveyCases())
-}
-
-func TestSurveyWS(t *testing.T) {
-	RunTestsWS(t, surveyCases())
-}
-
-func TestSurveyWSS(t *testing.T) {
-	RunTestsWSS(t, surveyCases())
-}
-
-func TestSurveyTTLZero(t *testing.T) {
-	SetTTLZero(t, xrespondent.NewSocket)
-}
-
-func TestSurveyTTLNegative(t *testing.T) {
-	SetTTLNegative(t, xrespondent.NewSocket)
-}
-
-func TestSurveyTTLTooBig(t *testing.T) {
-	SetTTLTooBig(t, xrespondent.NewSocket)
-}
-
-func TestSurveyTTLNotInt(t *testing.T) {
-	SetTTLNotInt(t, xrespondent.NewSocket)
-}
-
-func TestSurveyTTLSet(t *testing.T) {
-	SetTTL(t, xrespondent.NewSocket)
-}
-
-func TestSurveyTTLDrop(t *testing.T) {
-	TTLDropTest(t, surveyor.NewSocket, respondent.NewSocket,
-		xsurveyor.NewSocket, xrespondent.NewSocket)
 }


### PR DESCRIPTION
This cleans up most of the surveyor pattern tests, but the main
failing test is still left in place, to be rewritten.  Additionally
we would like richer tests for context support, verifying correct
handling of backtraces, survey cancellation, etc.