### PR TITLE
Fixes to closed handling.

### DIFF
--- a/internal/core/socket.go
+++ b/internal/core/socket.go
@@ -134,6 +134,7 @@ func (s *socket) Close() error {
 	s.listeners = nil
 	s.dialers = nil
 	s.pipes = nil
+	s.closed = true
 	s.Unlock()
 
 	for _, l := range listeners {
@@ -147,8 +148,7 @@ func (s *socket) Close() error {
 		p.Close()
 	}
 
-	s.proto.Close()
-	return nil
+	return s.proto.Close()
 }
 
 func (ctx context) Send(b []byte) error {

--- a/internal/test/closed.go
+++ b/internal/test/closed.go
@@ -1,0 +1,74 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"nanomsg.org/go/mangos/v2/protocol"
+	"testing"
+
+	"nanomsg.org/go/mangos/v2"
+)
+
+// VerifyClosedSend verifies that Send on the socket created returns protocol.ErrClosed if it is closed.
+func VerifyClosedSend(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	MustSucceed(t, s.Close())
+	err = s.Send([]byte{})
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrClosed)
+}
+
+// VerifyClosedRecv verifies that Recv on the socket created returns protocol.ErrClosed if it is closed.
+func VerifyClosedRecv(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	MustSucceed(t, s.Close())
+	_, err = s.Recv()
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrClosed)
+}
+
+// VerifyClosedClose verifies that Close on an already closed socket returns protocol.ErrClosed.
+func VerifyClosedClose(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	MustSucceed(t, s.Close())
+	err = s.Close()
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrClosed)
+}
+
+// VerifyClosedListen verifies that Listen returns protocol.ErrClosed on a closed socket.
+func VerifyClosedListen(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	MustSucceed(t, s.Close())
+	err = s.Listen(AddrTestInp())
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrClosed)
+}
+
+// VerifyClosedDial verifies that Dial returns protocol.ErrClosed on a closed socket.
+func VerifyClosedDial(t *testing.T, f func() (mangos.Socket, error)) {
+	s, err := f()
+	MustSucceed(t, err)
+	MustSucceed(t, s.Close())
+	err = s.DialOptions(AddrTestInp(), map[string]interface{}{
+		mangos.OptionDialAsynch: true,
+	})
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrClosed)
+}

--- a/protocol/star/closed_test.go
+++ b/protocol/star/closed_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package star
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
+)
+
+func TestStarClosed(t *testing.T) {
+	VerifyClosedRecv(t, NewSocket)
+	VerifyClosedSend(t, NewSocket)
+	VerifyClosedClose(t, NewSocket)
+	VerifyClosedDial(t, NewSocket)
+	VerifyClosedListen(t, NewSocket)
+}

--- a/protocol/xrespondent/closed_test.go
+++ b/protocol/xrespondent/closed_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xrespondent
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
+)
+
+func TestXRespondentClosed(t *testing.T) {
+	VerifyClosedRecv(t, NewSocket)
+	VerifyClosedSend(t, NewSocket)
+	VerifyClosedClose(t, NewSocket)
+	VerifyClosedDial(t, NewSocket)
+	VerifyClosedListen(t, NewSocket)
+}

--- a/protocol/xrespondent/xrespondent.go
+++ b/protocol/xrespondent/xrespondent.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -71,7 +71,14 @@ func init() {
 // we should send to.
 func (s *socket) SendMsg(m *protocol.Message) error {
 
+	s.Lock()
+	if s.closed {
+		s.Unlock()
+		return protocol.ErrClosed
+	}
+
 	if len(m.Header) < 4 {
+		s.Unlock()
 		m.Free()
 		return nil
 	}
@@ -80,7 +87,6 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 	hdr := m.Header
 	m.Header = m.Header[4:]
 
-	s.Lock()
 	p, ok := s.pipes[id]
 	if !ok {
 		s.Unlock()

--- a/protocol/xstar/closed_test.go
+++ b/protocol/xstar/closed_test.go
@@ -1,0 +1,30 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xstar
+
+import (
+	"testing"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
+)
+
+func TestXStarClosed(t *testing.T) {
+	VerifyClosedRecv(t, NewSocket)
+	VerifyClosedSend(t, NewSocket)
+	VerifyClosedClose(t, NewSocket)
+	VerifyClosedDial(t, NewSocket)
+	VerifyClosedListen(t, NewSocket)
+}


### PR DESCRIPTION
This includes a number of extra tests to improve coverage over
a few protocols.  This also changes Close() to no longer be
idempotent -- a second Close() returns an error now.