### PR TITLE
Wait for the transport send/recv test to complete.

### DIFF
--- a/test/transport.go
+++ b/test/transport.go
@@ -218,8 +218,13 @@ func (tt *TranTest) TestSendRecv(t *testing.T) {
 		return
 	}
 
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
 	go func() {
 		defer close(ch)
+		defer wg.Done()
 
 		// Client side
 		t.Logf("Connecting REQ on %s", tt.addr)
@@ -328,6 +333,8 @@ func (tt *TranTest) TestSendRecv(t *testing.T) {
 		t.Error("Client timeout?")
 		return
 	}
+
+	wg.Wait()
 }
 
 // TestScheme tests the Scheme() entry point on the transport.

--- a/transport/inproc/inproc_test.go
+++ b/transport/inproc/inproc_test.go
@@ -38,7 +38,7 @@ func TestInpSendRecv(t *testing.T) {
 	tt.TestSendRecv(t)
 }
 
-func TestInpSchem(t *testing.T) {
+func TestInpScheme(t *testing.T) {
 	tt.TestScheme(t)
 }
 


### PR DESCRIPTION
This should resolve occasional failures in the inproc test.