### PR TITLE
More test coverage for xrespondent.

### DIFF
--- a/internal/test/raw.go
+++ b/internal/test/raw.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"nanomsg.org/go/mangos/v2/protocol"
 	"testing"
 
 	"nanomsg.org/go/mangos/v2"
@@ -37,6 +38,11 @@ func VerifyRaw(t *testing.T, f func() (mangos.Socket, error)) {
 	MustFail(t, err)
 	err = s.SetOption(mangos.OptionRaw, 1)
 	MustFail(t, err)
+
+	// Raw Sockets also don't support contexts.
+	_, err = s.OpenContext()
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrProtoOp)
 }
 
 // VerifyCooked verifies that the socket created is cooked, and cannot be changed to raw.

--- a/protocol/xrespondent/ttl_test.go
+++ b/protocol/xrespondent/ttl_test.go
@@ -18,8 +18,25 @@ import (
 	"testing"
 
 	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/all"
 )
 
-func TestXRespondentRaw(t *testing.T) {
-	VerifyRaw(t, NewSocket)
+func TestXRespondentTTLZero(t *testing.T) {
+	SetTTLZero(t, NewSocket)
+}
+
+func TestXRespondentTTLNegative(t *testing.T) {
+	SetTTLNegative(t, NewSocket)
+}
+
+func TestXRespondentTTLTooBig(t *testing.T) {
+	SetTTLTooBig(t, NewSocket)
+}
+
+func TestXRespondentTTLNotInt(t *testing.T) {
+	SetTTLNotInt(t, NewSocket)
+}
+
+func TestXRespondentTTLSet(t *testing.T) {
+	SetTTL(t, NewSocket)
 }

--- a/protocol/xrespondent/xrespondent_test.go
+++ b/protocol/xrespondent/xrespondent_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package xrespondent
+
+import (
+	"nanomsg.org/go/mangos/v2"
+	"nanomsg.org/go/mangos/v2/protocol"
+	"testing"
+	"time"
+
+	. "nanomsg.org/go/mangos/v2/internal/test"
+	_ "nanomsg.org/go/mangos/v2/transport/inproc"
+)
+
+func TestXRespondentIdentity(t *testing.T) {
+	s, err := NewSocket()
+	defer s.Close()
+	MustSucceed(t, err)
+	id := s.Info()
+	MustBeTrue(t, id.Peer == mangos.ProtoSurveyor)
+	MustBeTrue(t, id.PeerName == "surveyor")
+	MustBeTrue(t, id.Self == mangos.ProtoRespondent)
+	MustBeTrue(t, id.SelfName == "respondent")
+}
+
+func TestXRespondentNoHeader(t *testing.T) {
+	s, err := NewSocket()
+	MustSucceed(t, err)
+	defer s.Close()
+
+	m := mangos.NewMessage(0)
+
+	MustSucceed(t, s.SendMsg(m))
+}
+
+func TestXRespondentMismatchHeader(t *testing.T) {
+	s, err := NewSocket()
+	MustSucceed(t, err)
+	defer s.Close()
+
+	m := mangos.NewMessage(0)
+	m.Header = append(m.Header, []byte{1, 1, 1, 1}...)
+
+	MustSucceed(t, s.SendMsg(m))
+}
+
+func TestXRespondentRecvTimeout(t *testing.T) {
+	s, err := NewSocket()
+	MustSucceed(t, err)
+	defer s.Close()
+
+	MustSucceed(t, s.SetOption(mangos.OptionRecvDeadline, time.Millisecond))
+	m, err := s.RecvMsg()
+	MustBeNil(t, m)
+	MustFail(t, err)
+	MustBeTrue(t, err == protocol.ErrRecvTimeout)
+}


### PR DESCRIPTION
While here, raw mode now verifies that contexts can't be opened.