### PR TITLE
Improvements to flow handling for XSUB protocol.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/gorilla/websocket v1.4.1
 	golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35 // indirect
 )
+
+go 1.13

--- a/internal/test/must.go
+++ b/internal/test/must.go
@@ -16,6 +16,7 @@ package test
 
 import (
 	"reflect"
+	"runtime"
 	"testing"
 )
 
@@ -23,7 +24,8 @@ import (
 // If it is not nil, we call t.Fatalf() to fail the test immediately.
 func MustSucceed(t *testing.T, e error) {
 	if e != nil {
-		t.Fatalf("Error is not nil: %v", e)
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Error is not nil: %v", file, line, e)
 	}
 }
 
@@ -31,34 +33,39 @@ func MustSucceed(t *testing.T, e error) {
 // If it is nil, the test is a fatal failure.
 func MustFail(t *testing.T, e error) {
 	if e == nil {
-		t.Fatalf("Error is nil")
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Error is nil", file, line)
 	}
 }
 
 // MustBeTrue verifies that the condition is true.
 func MustBeTrue(t *testing.T, b bool) {
 	if !b {
-		t.Fatalf("Condition is false")
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Condition is false", file, line)
 	}
 }
 
 // MustBeFalse verifies that the condition is true.
 func MustBeFalse(t *testing.T, b bool) {
 	if b {
-		t.Fatalf("Condition is true")
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Condition is true", file, line)
 	}
 }
 
 // MustNotBeNil verifies that the provided value is not nil
 func MustNotBeNil(t *testing.T, v interface{}) {
 	if reflect.ValueOf(v).IsNil() {
-		t.Fatalf("Value is nil")
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Value is nil", file, line)
 	}
 }
 
 // MustBeNil verifies that the provided value is nil
 func MustBeNil(t *testing.T, v interface{}) {
 	if !reflect.ValueOf(v).IsNil() {
-		t.Fatalf("Value is not nil: %v", v)
+		_, file, line, _ := runtime.Caller(1)
+		t.Fatalf("Failed at %s:%d: Value is not nil", file, line)
 	}
 }

--- a/protocol/xsub/xsub.go
+++ b/protocol/xsub/xsub.go
@@ -201,6 +201,16 @@ outer:
 		case <-p.s.closeq:
 			m.Free()
 			break outer
+		default:
+			// Yank the oldest message first, so we can
+			// inject new stuff.  We really prefer to have
+			// more recent data.
+			select {
+			case m2 := <-p.s.recvq:
+				m2.Free()
+			default:
+			}
+			p.s.recvq<-m
 		}
 	}
 	p.close()

--- a/test/pubsub_test.go
+++ b/test/pubsub_test.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2019 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -130,26 +130,6 @@ func pubCases() []TestCase {
 
 }
 
-func TestPubSubTCP(t *testing.T) {
-	RunTestsTCP(t, pubCases())
-}
-
-func TestPubSubIPC(t *testing.T) {
-	RunTestsIPC(t, pubCases())
-}
-
 func TestPubSubInp(t *testing.T) {
 	RunTestsInp(t, pubCases())
-}
-
-func TestPubSubTLS(t *testing.T) {
-	RunTestsTLS(t, pubCases())
-}
-
-func TestPubSubWS(t *testing.T) {
-	RunTestsWS(t, pubCases())
-}
-
-func TestPubSubWSS(t *testing.T) {
-	RunTestsWSS(t, pubCases())
 }


### PR DESCRIPTION
The old code tended to favor discarding *new* messages, but for
most PUB/SUB consumers we would rather discard an older message
as newer data is usually preferred.

This includes a bunch more test code too.