### PR TITLE
Various SUB fixes.

### DIFF
--- a/internal/test/operations.go
+++ b/internal/test/operations.go
@@ -25,24 +25,22 @@ import (
 func CannotSend(t *testing.T, f func() (mangos.Socket, error)) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 
+	// Not all protocols support this option, but try.
 	_ = s.SetOption(mangos.OptionSendDeadline, time.Millisecond)
 
-	err = s.Send([]byte{0, 1, 2, 3})
-	MustFail(t, err)
-	MustBeTrue(t, err == mangos.ErrProtoOp)
+	MustBeError(t, s.Send([]byte{0, 1, 2, 3}), mangos.ErrProtoOp)
+	MustSucceed(t, s.Close())
 }
 
 // CannotRecv verifies that the socket cannot recv.
 func CannotRecv(t *testing.T, f func() (mangos.Socket, error)) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 
 	_ = s.SetOption(mangos.OptionRecvDeadline, time.Millisecond)
 
 	_, err = s.Recv()
-	MustFail(t, err)
-	MustBeTrue(t, err == mangos.ErrProtoOp)
+	MustBeError(t, err, mangos.ErrProtoOp)
+	MustSucceed(t, s.Close())
 }

--- a/internal/test/options.go
+++ b/internal/test/options.go
@@ -25,18 +25,17 @@ import (
 func VerifyInvalidOption(t *testing.T, f func() (mangos.Socket, error)) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	_, err = s.GetOption("nosuchoption")
 	MustBeError(t, err, mangos.ErrBadOption)
 
 	MustBeError(t, s.SetOption("nosuchoption", 0), mangos.ErrBadOption)
+	MustSucceed(t, s.Close())
 }
 
 // VerifyOptionDuration validates time.Duration options
 func VerifyOptionDuration(t *testing.T, f func() (mangos.Socket, error), option string) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	val, err := s.GetOption(option)
 	MustSucceed(t, err)
 	MustBeTrue(t, reflect.TypeOf(val) == reflect.TypeOf(time.Duration(0)))
@@ -48,15 +47,15 @@ func VerifyOptionDuration(t *testing.T, f func() (mangos.Socket, error), option 
 
 	MustBeError(t, s.SetOption(option, time.Now()), mangos.ErrBadValue)
 	MustBeError(t, s.SetOption(option, "junk"), mangos.ErrBadValue)
+	MustSucceed(t, s.Close())
 }
 
 func VerifyOptionInt(t *testing.T, f func() (mangos.Socket, error), option string) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	val, err := s.GetOption(option)
 	MustSucceed(t, err)
-	MustBeTrue(t, reflect.TypeOf(val) == reflect.TypeOf(int(1)))
+	MustBeTrue(t, reflect.TypeOf(val) == reflect.TypeOf(1))
 
 	MustSucceed(t, s.SetOption(option, 2))
 	val, err = s.GetOption(option)
@@ -65,12 +64,12 @@ func VerifyOptionInt(t *testing.T, f func() (mangos.Socket, error), option strin
 
 	MustBeError(t, s.SetOption(option, time.Now()), mangos.ErrBadValue)
 	MustBeError(t, s.SetOption(option, "junk"), mangos.ErrBadValue)
+	MustSucceed(t, s.Close())
 }
 
 func VerifyOptionBool(t *testing.T, f func() (mangos.Socket, error), option string) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	val, err := s.GetOption(option)
 	MustSucceed(t, err)
 	MustBeTrue(t, reflect.TypeOf(val) == reflect.TypeOf(true))
@@ -87,4 +86,5 @@ func VerifyOptionBool(t *testing.T, f func() (mangos.Socket, error), option stri
 
 	MustBeError(t, s.SetOption(option, time.Now()), mangos.ErrBadValue)
 	MustBeError(t, s.SetOption(option, "junk"), mangos.ErrBadValue)
+	MustSucceed(t, s.Close())
 }

--- a/internal/test/raw.go
+++ b/internal/test/raw.go
@@ -25,7 +25,6 @@ import (
 func VerifyRaw(t *testing.T, f func() (mangos.Socket, error)) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	val, err := s.GetOption(mangos.OptionRaw)
 	MustSucceed(t, err)
 	if b, ok := val.(bool); ok {
@@ -43,13 +42,13 @@ func VerifyRaw(t *testing.T, f func() (mangos.Socket, error)) {
 	_, err = s.OpenContext()
 	MustFail(t, err)
 	MustBeTrue(t, err == protocol.ErrProtoOp)
+	MustSucceed(t, s.Close())
 }
 
 // VerifyCooked verifies that the socket created is cooked, and cannot be changed to raw.
 func VerifyCooked(t *testing.T, f func() (mangos.Socket, error)) {
 	s, err := f()
 	MustSucceed(t, err)
-	defer s.Close()
 	val, err := s.GetOption(mangos.OptionRaw)
 	MustSucceed(t, err)
 	if b, ok := val.(bool); ok {
@@ -62,4 +61,5 @@ func VerifyCooked(t *testing.T, f func() (mangos.Socket, error)) {
 	MustFail(t, err)
 	err = s.SetOption(mangos.OptionRaw, 0)
 	MustFail(t, err)
+	MustSucceed(t, s.Close())
 }

--- a/protocol/sub/sub_test.go
+++ b/protocol/sub/sub_test.go
@@ -15,7 +15,10 @@
 package sub
 
 import (
+	"math/rand"
 	"nanomsg.org/go/mangos/v2"
+	"nanomsg.org/go/mangos/v2/protocol/pub"
+	"sync"
 	"testing"
 	"time"
 
@@ -31,6 +34,7 @@ func TestSubIdentity(t *testing.T) {
 	MustBeTrue(t, id.Peer == mangos.ProtoPub)
 	MustBeTrue(t, id.SelfName == "sub")
 	MustBeTrue(t, id.PeerName == "pub")
+	MustSucceed(t, s.Close())
 }
 
 func TestSubCooked(t *testing.T) {
@@ -63,7 +67,7 @@ func TestSubRecvDeadline(t *testing.T) {
 	MustFail(t, e)
 	MustBeTrue(t, e == mangos.ErrRecvTimeout)
 	MustBeNil(t, m)
-	_ = s.Close()
+	MustSucceed(t, s.Close())
 }
 
 func TestSubSubscribe(t *testing.T) {
@@ -75,9 +79,219 @@ func TestSubSubscribe(t *testing.T) {
 	MustSucceed(t, s.SetOption(mangos.OptionSubscribe, []byte{0, 1}))
 	MustBeError(t, s.SetOption(mangos.OptionSubscribe, 1), mangos.ErrBadValue)
 
+	MustBeError(t, s.SetOption(mangos.OptionUnsubscribe, "nope"), mangos.ErrBadValue)
 	MustSucceed(t, s.SetOption(mangos.OptionUnsubscribe, "topic"))
 	MustSucceed(t, s.SetOption(mangos.OptionUnsubscribe, []byte{0, 1}))
-	MustBeError(t, s.SetOption(mangos.OptionUnsubscribe, "nope"), mangos.ErrBadValue)
 	MustBeError(t, s.SetOption(mangos.OptionUnsubscribe, false), mangos.ErrBadValue)
-	_ = s.Close()
+	MustSucceed(t, s.Close())
+}
+
+func TestSubUnsubscribeDrops(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	p, e := pub.NewSocket()
+	MustSucceed(t, e)
+	a := AddrTestInp()
+
+	MustSucceed(t, s.SetOption(mangos.OptionReadQLen, 50))
+	MustSucceed(t, p.Listen(a))
+	MustSucceed(t, s.Dial(a))
+
+	time.Sleep(time.Millisecond * 20)
+
+	MustSucceed(t, s.SetOption(mangos.OptionSubscribe, "1"))
+	MustSucceed(t, s.SetOption(mangos.OptionSubscribe, "2"))
+
+	for i := 0; i < 10; i++ {
+		MustSucceed(t, p.Send([]byte("1")))
+		MustSucceed(t, p.Send([]byte("2")))
+	}
+
+	time.Sleep(time.Millisecond * 10)
+	MustSucceed(t, s.SetOption(mangos.OptionUnsubscribe, "1"))
+	for i := 0; i < 10; i++ {
+		v, e := s.Recv()
+		MustSucceed(t, e)
+		MustBeTrue(t, string(v) == "2")
+	}
+
+	MustSucceed(t, p.Close())
+	MustSucceed(t, s.Close())
+}
+
+func TestSubRecvQLen(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	p, e := pub.NewSocket()
+	MustSucceed(t, e)
+	addr := AddrTestInp()
+	MustSucceed(t, s.SetOption(mangos.OptionRecvDeadline, time.Millisecond*10))
+	MustSucceed(t, s.SetOption(mangos.OptionReadQLen, 2))
+	MustSucceed(t, s.SetOption(mangos.OptionSubscribe, []byte{}))
+
+	MustSucceed(t, s.Listen(addr))
+	MustSucceed(t, p.Dial(addr))
+	time.Sleep(time.Millisecond * 50)
+
+	MustSucceed(t, p.Send([]byte("one")))
+	MustSucceed(t, p.Send([]byte("two")))
+	MustSucceed(t, p.Send([]byte("three")))
+	time.Sleep(time.Millisecond * 50)
+
+	MustSucceed(t, e)
+	m, e := s.RecvMsg()
+	MustSucceed(t, e)
+	MustNotBeNil(t, m)
+	m, e = s.RecvMsg()
+	MustSucceed(t, e)
+	MustNotBeNil(t, m)
+	// this verifies we discarded the oldest first
+	MustBeTrue(t, string(m.Body) == "three")
+	m, e = s.RecvMsg()
+	MustFail(t, e)
+	MustBeTrue(t, e == mangos.ErrRecvTimeout)
+	MustSucceed(t, p.Close())
+	MustSucceed(t, s.Close())
+}
+
+func TestSubRecvQLenResizeDiscard(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	p, e := pub.NewSocket()
+	MustSucceed(t, e)
+	addr := AddrTestInp()
+	MustSucceed(t, s.SetOption(mangos.OptionRecvDeadline, time.Millisecond*100))
+	MustSucceed(t, s.SetOption(mangos.OptionReadQLen, 10))
+	MustSucceed(t, s.SetOption(mangos.OptionSubscribe, []byte{}))
+	MustSucceed(t, s.Listen(addr))
+	MustSucceed(t, p.Dial(addr))
+	time.Sleep(time.Millisecond * 50)
+
+	MustSucceed(t, p.Send([]byte("one")))
+	MustSucceed(t, p.Send([]byte("two")))
+	MustSucceed(t, p.Send([]byte("three")))
+
+	// Sleep allows the messages to arrive in the recvq before we resize.
+	time.Sleep(time.Millisecond * 50)
+
+	// Shrink it
+	MustSucceed(t, s.SetOption(mangos.OptionReadQLen, 2))
+
+	// We should be able to get the first message, which should be "two"
+	m, e := s.RecvMsg()
+	MustSucceed(t, e)
+	MustNotBeNil(t, m)
+
+	m, e = s.RecvMsg()
+	MustSucceed(t, e)
+	MustNotBeNil(t, m)
+	// this verifies we discarded the oldest first
+	MustBeTrue(t, string(m.Body) == "three")
+	m, e = s.RecvMsg()
+	MustFail(t, e)
+	MustBeTrue(t, e == mangos.ErrRecvTimeout)
+	MustSucceed(t, p.Close())
+	MustSucceed(t, s.Close())
+}
+
+func TestSubContextOpen(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	c, e := s.OpenContext()
+	MustSucceed(t, e)
+
+	// Also test that we can't send on this.
+	MustBeError(t, c.Send([]byte{}), mangos.ErrProtoOp)
+	MustSucceed(t, c.Close())
+	MustSucceed(t, s.Close())
+
+	MustBeError(t, c.Close(), mangos.ErrClosed)
+}
+
+func TestSubSocketCloseContext(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	c, e := s.OpenContext()
+	MustSucceed(t, e)
+
+	MustSucceed(t, s.Close())
+
+	// Verify that the context is already closed (closing the socket
+	// closes the context.)
+	MustBeError(t, c.Close(), mangos.ErrClosed)
+}
+
+func TestSubMultiContexts(t *testing.T) {
+	s, e := NewSocket()
+	MustSucceed(t, e)
+	MustNotBeNil(t, s)
+
+	c1, e := s.OpenContext()
+	MustSucceed(t, e)
+	MustNotBeNil(t, c1)
+	c2, e := s.OpenContext()
+	MustSucceed(t, e)
+	MustNotBeNil(t, c2)
+	MustBeTrue(t, c1 != c2)
+
+	MustSucceed(t, c1.SetOption(mangos.OptionSubscribe, "1"))
+	MustSucceed(t, c2.SetOption(mangos.OptionSubscribe, "2"))
+
+	p, e := pub.NewSocket()
+	MustSucceed(t, e)
+	MustNotBeNil(t, p)
+
+	a := AddrTestInp()
+
+	MustSucceed(t, p.Listen(a))
+	MustSucceed(t, s.Dial(a))
+
+	// Make sure we have dialed properly
+	time.Sleep(time.Millisecond * 10)
+
+	sent := []int{0, 0}
+	recv := []int{0, 0}
+	mesg := []string{"1", "2"}
+	var wg sync.WaitGroup
+	wg.Add(2)
+	fn := func(c mangos.Context, index int) {
+		for {
+			m, e := c.RecvMsg()
+			if e == nil {
+				MustBeTrue(t, string(m.Body) == mesg[index])
+				recv[index]++
+				continue
+			}
+			MustBeError(t, e, mangos.ErrClosed)
+			wg.Done()
+			return
+		}
+	}
+
+	go fn(c1, 0)
+	go fn(c2, 1)
+
+	rng := rand.NewSource(32)
+
+	// Choose an odd number so that it does not divide evenly, ensuring
+	// that there will be a non-equal distribution.  Note that with our
+	// fixed seed above, it works out to 41 & 60.
+	for i := 0; i < 101; i++ {
+		index := int(rng.Int63() & 1)
+		MustSucceed(t, p.Send([]byte(mesg[index])))
+		sent[index]++
+	}
+
+	// Give time for everything to be delivered.
+	time.Sleep(time.Millisecond * 50)
+	MustSucceed(t, c1.Close())
+	MustSucceed(t, c2.Close())
+	wg.Wait()
+
+	MustBeTrue(t, sent[0] != sent[1])
+	MustBeTrue(t, sent[0] == recv[0])
+	MustBeTrue(t, sent[1] == recv[1])
+
+	MustSucceed(t, s.Close())
+	MustSucceed(t, p.Close())
 }

--- a/protocol/xsub/xsub.go
+++ b/protocol/xsub/xsub.go
@@ -208,7 +208,13 @@ outer:
 				m2.Free()
 			default:
 			}
-			p.s.recvq <- m
+			// We might be contending with other pipes; in that
+			// case we've done the best we can; give up.
+			select {
+			case p.s.recvq <- m:
+			default:
+				m.Free()
+			}
 		}
 	}
 	p.close()

--- a/protocol/xsub/xsub_test.go
+++ b/protocol/xsub/xsub_test.go
@@ -113,11 +113,14 @@ func TestXSubRecvQLen(t *testing.T) {
 	MustSucceed(t, s.SetOption(mangos.OptionReadQLen, 2))
 	MustSucceed(t, s.Listen(addr))
 	MustSucceed(t, p.Dial(addr))
+	time.Sleep(time.Millisecond * 50)
+
 	MustSucceed(t, p.Send([]byte("one")))
 	MustSucceed(t, p.Send([]byte("two")))
 	MustSucceed(t, p.Send([]byte("three")))
-	MustSucceed(t, e)
 	time.Sleep(time.Millisecond * 50)
+
+	MustSucceed(t, e)
 	m, e := s.RecvMsg()
 	MustSucceed(t, e)
 	MustNotBeNil(t, m)


### PR DESCRIPTION
SUB context close was incorrectly closing the socket.
This change also prefers new messages to old ones when discarding.
XSUB had a potential hang regression in it's most recent changes.

This also adds a lot more testing of the Sub protocol, including
multiple contexts, unsubcription handling, resizes.