### PR TITLE
Inject protocol errors for testing purposes.

### DIFF
--- a/transport/conn.go
+++ b/transport/conn.go
@@ -138,8 +138,8 @@ func NewConnPipe(c net.Conn, proto ProtocolInfo, options map[string]interface{})
 	}
 
 	p.options[mangos.OptionMaxRecvSize] = 0
-	p.options[mangos.OptionLocalAddr] = p.c.LocalAddr()
-	p.options[mangos.OptionRemoteAddr] = p.c.RemoteAddr()
+	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
+	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
 	for n, v := range options {
 		p.options[n] = v
 	}

--- a/transport/connipc_posix.go
+++ b/transport/connipc_posix.go
@@ -34,28 +34,26 @@ func NewConnPipeIPC(c net.Conn, proto ProtocolInfo) ConnPipe {
 			maxrx:   0,
 		},
 	}
+	p.options[mangos.OptionMaxRecvSize] = 0
+	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
+	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
 	return p
 }
 
 func (p *connipc) Send(msg *Message) error {
 
+	var buff = net.Buffers{}
+
+	// Serialize the length header
 	l := uint64(len(msg.Header) + len(msg.Body))
-	var err error
+	lbyte := make([]byte, 9)
+	lbyte[0] = 1
+	binary.BigEndian.PutUint64(lbyte[1:], l)
 
-	// send length header
-	header := make([]byte, 9)
-	header[0] = 1
-	binary.BigEndian.PutUint64(header[1:], l)
+	// Attach the length header along with the actual header and body
+	buff = append(buff, lbyte, msg.Header, msg.Body)
 
-	if _, err = p.c.Write(header[:]); err != nil {
-		return err
-	}
-
-	if _, err = p.c.Write(msg.Header); err != nil {
-		return err
-	}
-	// hope this works
-	if _, err = p.c.Write(msg.Body); err != nil {
+	if _, err := buff.WriteTo(p.c); err != nil {
 		return err
 	}
 	msg.Free()

--- a/transport/connipc_windows.go
+++ b/transport/connipc_windows.go
@@ -34,6 +34,9 @@ func NewConnPipeIPC(c net.Conn, proto ProtocolInfo) ConnPipe {
 			maxrx:   0,
 		},
 	}
+	p.options[mangos.OptionMaxRecvSize] = 0
+	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
+	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
 
 	return p
 }
@@ -78,7 +81,7 @@ func (p *connipc) Recv() (*Message, error) {
 	}
 
 	// Limit messages to the maximum receive value, if not
-	// unlimited.  This avoids a potential denaial of service.
+	// unlimited.  This avoids a potential denial of service.
 	if sz < 0 || (p.maxrx > 0 && sz > int64(p.maxrx)) {
 		return nil, mangos.ErrTooLong
 	}

--- a/transport/ipc/ipc_test.go
+++ b/transport/ipc/ipc_test.go
@@ -89,3 +89,9 @@ func TestIpcMessageSize(t *testing.T) {
 func TestIpcMessageHeader(t *testing.T) {
 	test.TranVerifyMessageHeader(t, tran, nil, nil)
 }
+func TestIpcVerifyPipeAddresses(t *testing.T) {
+	test.TranVerifyPipeAddresses(t, tran, nil, nil)
+}
+func TestIpcVerifyPipeOptions(t *testing.T) {
+	test.TranVerifyPipeOptions2(t, tran, nil, nil)
+}

--- a/transport/tcp/tcp_test.go
+++ b/transport/tcp/tcp_test.go
@@ -15,94 +15,94 @@
 package tcp
 
 import (
+	"net"
 	"testing"
 	"time"
 
 	"nanomsg.org/go/mangos/v2"
-	"nanomsg.org/go/mangos/v2/internal/test"
+	. "nanomsg.org/go/mangos/v2/internal/test"
 )
 
 var tran = Transport
 
 func TestTcpRecvMax(t *testing.T) {
-	test.TranVerifyMaxRecvSize(t, tran, nil, nil)
+	TranVerifyMaxRecvSize(t, tran, nil, nil)
 }
 
 func TestTcpOptions(t *testing.T) {
-	test.TranVerifyInvalidOption(t, tran)
-	test.TranVerifyIntOption(t, tran, mangos.OptionMaxRecvSize)
-	test.TranVerifyNoDelayOption(t, tran)
-	test.TranVerifyKeepAliveOption(t, tran)
+	TranVerifyInvalidOption(t, tran)
+	TranVerifyIntOption(t, tran, mangos.OptionMaxRecvSize)
+	TranVerifyNoDelayOption(t, tran)
+	TranVerifyKeepAliveOption(t, tran)
 }
 
 func TestTcpScheme(t *testing.T) {
-	test.TranVerifyScheme(t, tran)
+	TranVerifyScheme(t, tran)
 }
 func TestTcpAcceptWithoutListen(t *testing.T) {
-	test.TranVerifyAcceptWithoutListen(t, tran)
+	TranVerifyAcceptWithoutListen(t, tran)
 }
 func TestTcpListenAndAccept(t *testing.T) {
-	test.TranVerifyListenAndAccept(t, tran, nil, nil)
+	TranVerifyListenAndAccept(t, tran, nil, nil)
 }
 func TestTcpDuplicateListen(t *testing.T) {
-	test.TranVerifyDuplicateListen(t, tran, nil)
+	TranVerifyDuplicateListen(t, tran, nil)
 }
 func TestTcpConnectionRefused(t *testing.T) {
-	test.TranVerifyConnectionRefused(t, tran, nil)
+	TranVerifyConnectionRefused(t, tran, nil)
 }
 func TestTcpHandshake(t *testing.T) {
-	test.TranVerifyHandshakeFail(t, tran, nil, nil)
+	TranVerifyHandshakeFail(t, tran, nil, nil)
 }
 func TestTcpSendRecv(t *testing.T) {
-	test.TranVerifySendRecv(t, tran, nil, nil)
+	TranVerifySendRecv(t, tran, nil, nil)
 }
 func TestTcpAnonymousPort(t *testing.T) {
-	test.TranVerifyAnonymousPort(t, "tcp://127.0.0.1:0", nil, nil)
+	TranVerifyAnonymousPort(t, "tcp://127.0.0.1:0", nil, nil)
 }
 func TestTcpInvalidDomain(t *testing.T) {
-	test.TranVerifyBadAddress(t, "tcp://invalid.invalid", nil, nil)
+	TranVerifyBadAddress(t, "tcp://invalid.invalid", nil, nil)
 }
 func TestTcpInvalidLocalIP(t *testing.T) {
-	test.TranVerifyBadLocalAddress(t, "tcp://1.1.1.1:80", nil)
+	TranVerifyBadLocalAddress(t, "tcp://1.1.1.1:80", nil)
 }
 func TestTcpBroadcastIP(t *testing.T) {
-	test.TranVerifyBadAddress(t, "tcp://255.255.255.255:80", nil, nil)
+	TranVerifyBadAddress(t, "tcp://255.255.255.255:80", nil, nil)
 }
-
 func TestTcpListenerClosed(t *testing.T) {
-	test.TranVerifyListenerClosed(t, tran, nil)
+	TranVerifyListenerClosed(t, tran, nil)
 }
 
 func TestTcpResolverChange(t *testing.T) {
-	sock := test.GetMockSocket()
-	defer test.MustClose(t, sock)
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
 
-	addr := test.AddrTestTCP()
-	test.MustSucceed(t, sock.Listen(addr))
+	addr := AddrTestTCP()
+	MustSucceed(t, sock.Listen(addr))
 
 	d, e := tran.NewDialer(addr, sock)
-	test.MustSucceed(t, e)
+	MustSucceed(t, e)
 	td := d.(*dialer)
 	addr = td.addr
 	td.addr = "tcp://invalid.invalid:80"
 	p, e := d.Dial()
-	test.MustFail(t, e)
-	test.MustBeTrue(t, p == nil)
+	MustFail(t, e)
+	MustBeTrue(t, p == nil)
 
 	td.addr = addr
 	p, e = d.Dial()
-	test.MustSucceed(t, e)
-	test.MustSucceed(t, p.Close())
+	MustSucceed(t, e)
+	MustSucceed(t, p.Close())
 }
 
 func TestTcpAcceptAbort(t *testing.T) {
-	sock := test.GetMockSocket()
-	defer test.MustClose(t, sock)
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
 
-	addr := test.AddrTestTCP()
+	addr := AddrTestTCP()
 	l, e := tran.NewListener(addr, sock)
-	test.MustSucceed(t, e)
-	test.MustSucceed(t, l.Listen())
+	MustSucceed(t, e)
+	MustSucceed(t, l.Listen())
 	_ = l.(*listener).l.Close()
 	// This will make the accept loop spin hard, but nothing much
 	// we can do about it.
@@ -110,8 +110,68 @@ func TestTcpAcceptAbort(t *testing.T) {
 }
 
 func TestTcpMessageSize(t *testing.T) {
-	test.TranVerifyMessageSizes(t, tran, nil, nil)
+	TranVerifyMessageSizes(t, tran, nil, nil)
 }
 func TestTcpMessageHeader(t *testing.T) {
-	test.TranVerifyMessageHeader(t, tran, nil, nil)
+	TranVerifyMessageHeader(t, tran, nil, nil)
+}
+func TestTcpVerifyPipeAddresses(t *testing.T) {
+	TranVerifyPipeAddresses(t, tran, nil, nil)
+}
+func TestTcpVerifyPipeOptions(t *testing.T) {
+	TranVerifyPipeOptions2(t, tran, nil, nil)
+}
+
+type testAddr string
+
+func (a testAddr) testDial() (net.Conn, error) {
+	return net.Dial("tcp", string(a)[len("tcp://"):])
+}
+
+func TestTcpAbortHandshake(t *testing.T) {
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
+	addr := AddrTestTCP()
+	l, e := sock.NewListener(addr, nil)
+	MustSucceed(t, e)
+	MustSucceed(t, l.Listen())
+	c, e := testAddr(addr).testDial()
+	MustSucceed(t, e)
+	MustSucceed(t, c.Close())
+}
+
+func TestTcpBadHandshake(t *testing.T) {
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
+	addr := AddrTestTCP()
+	l, e := sock.NewListener(addr, nil)
+	MustSucceed(t, e)
+	MustSucceed(t, l.Listen())
+	TranSendConnBadHandshakes(t, testAddr(addr).testDial)
+}
+
+func TestTcpBadRecv(t *testing.T) {
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
+	addr := AddrTestTCP()
+	l, e := sock.NewListener(addr, nil)
+	MustSucceed(t, e)
+	MustSucceed(t, l.Listen())
+	TranSendBadMessages(t, sock.Info().Peer, false, testAddr(addr).testDial)
+}
+
+func TestTcpSendAbort(t *testing.T) {
+	sock := GetMockSocket()
+	defer MustClose(t, sock)
+	addr := AddrTestTCP()
+	l, e := sock.NewListener(addr, nil)
+	MustSucceed(t, e)
+	MustSucceed(t, l.Listen())
+	c, e := testAddr(addr).testDial()
+	MustSucceed(t, e)
+	TranConnHandshake(t, c, sock.Info().Peer)
+	MustSend(t, sock, make([]byte, 2*1024*1024)) // TCP window size is 64k
+	time.Sleep(time.Millisecond * 100)
+	MustSend(t, sock, make([]byte, 2*1024*1024)) // TCP window size is 64k
+	MustSucceed(t, c.Close())
 }


### PR DESCRIPTION
This injects various failure modes into the handshake and
message exchange for the connection oriented protocols (except
WebSocket, which is special.)