### PR TITLE
fix go doc cmd

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ Some examples are posted in the directories under `examples/` in this project.
 These examples are rewrites (in Go) of Tim Dysinger's
 http://nanomsg.org/gettingstarted/index.html[Getting Started with Nanomsg].
 
-Running `godoc` in the example directories will yield information about how
+Running `go doc` in the example directories will yield information about how
 to run each example program.
 
 Enjoy!


### PR DESCRIPTION
Hey,

just wanted to try the examples and got the following error.

```bash
$ cd examples/websocket
$ go version
go version go1.13 linux/amd64

$ godoc
Command 'godoc' not found, but can be installed with:
sudo apt install golang-golang-x-tools
```

This one works

```bash
$ go doc
websocket implements a simple websocket server for mangos, demonstrating how
to use multiplex multiple sockets on a single HTTP server instance.

The server listens, and offers three paths:

    - sub/    - SUB socket, publishes a message "PUB <count> <time>" each second
    - req/    - REQ socket, responds with a reply "REPLY <count> <time>"
    - static/ - static content, provided as ASCII "STATIC"

To use:

    $ go build .
    $ port=40899
    $ ./websocket server port & pid=$! && sleep 1
    $ ./websocket req $port
    $ ./websocket sub $port
    $ ./websocket static $port
    $ kill $pid
```

Hence the PR.