### PR TITLE
Lint Fixes

### DIFF
--- a/examples/context/context.go
+++ b/examples/context/context.go
@@ -89,6 +89,9 @@ func server(url string) {
 				die("can't create context on rep socket: %s", err)
 			}
 			msg, err = ctx.Recv()
+			if err != nil {
+				die("can't receive from context: %s", err)
+			}
 			fmt.Printf("Worker %d: Received request '%s'\n", id, string(msg))
 
 			// Sleep for a random amount of time to simulate "work"

--- a/examples/pipeline/pipeline.go
+++ b/examples/pipeline/pipeline.go
@@ -57,6 +57,9 @@ func node0(url string) {
 	for {
 		// Could also use sock.RecvMsg to get header
 		msg, err = sock.Recv()
+		if err != nil {
+			die("cannot receive from mangos Socket: %s", err.Error())
+		}
 		fmt.Printf("NODE0: RECEIVED \"%s\"\n", msg)
 
 		if string(msg) == "STOP" {

--- a/examples/reqrep/reqrep.go
+++ b/examples/reqrep/reqrep.go
@@ -60,6 +60,9 @@ func node0(url string) {
 	for {
 		// Could also use sock.RecvMsg to get header
 		msg, err = sock.Recv()
+		if err != nil {
+			die("cannot receive on rep socket: %s", err.Error())
+		}
 		if string(msg) == "DATE" { // no need to terminate
 			fmt.Println("NODE0: RECEIVED DATE REQUEST")
 			d := date()

--- a/internal/core/dialer.go
+++ b/internal/core/dialer.go
@@ -31,7 +31,6 @@ type dialer struct {
 	addr          string
 	closed        bool
 	active        bool
-	dialing       bool
 	asynch        bool
 	redialer      *time.Timer
 	reconnTime    time.Duration

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -549,6 +549,7 @@ func slowStart(_ *testing.T, cases []TestCase) bool {
 	}
 
 	timeout := time.After(time.Second * 5)
+Loop:
 	for numexit < needrdy {
 		select {
 		case <-timeout:
@@ -556,7 +557,7 @@ func slowStart(_ *testing.T, cases []TestCase) bool {
 				close(exitq)
 				exitqclosed = true
 			}
-			break
+			break Loop
 		case <-wakeq:
 			numexit++
 		}


### PR DESCRIPTION
I linted with `staticcheck`, and found:

1. dropped errors in the `examples`.
2. a `break` statement that was a bit of a damp squib, breaking a `select` instead of the `for` loop as was probably intended.
3. a stray `dialing` boolean in the `dialer` struct.