### PR TITLE
fixes #201 Requests respond with send timeout after some time

### DIFF
--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -113,7 +113,7 @@ func (p *pipe) sendCtx(c *context, m *protocol.Message) {
 		}
 	}
 	s.Lock()
-	if !c.closed && !p.closed {
+	if !s.closed && !p.closed {
 		s.readyq = append(s.readyq, p)
 		s.send()
 	}

--- a/protocol/req/req_test.go
+++ b/protocol/req/req_test.go
@@ -363,7 +363,7 @@ func TestReqCtxCloseRecv(t *testing.T) {
 // This sets up a bunch of contexts to run in parallel, and verifies that
 // they all seem to run with no mis-deliveries.
 func TestReqMultiContexts(t *testing.T) {
-	count := 30
+	count := 300
 	repeat := 20
 
 	self := GetSocket(t, NewSocket)
@@ -381,11 +381,13 @@ func TestReqMultiContexts(t *testing.T) {
 		c, e := self.OpenContext()
 		MustSucceed(t, e)
 		MustNotBeNil(t, c)
+		defer c.Close()
 
 		ctxs = append(ctxs, c)
 		topic := make([]byte, 4)
 		binary.BigEndian.PutUint32(topic, uint32(index))
 
+		MustSucceed(t, c.SetOption(mangos.OptionSendDeadline, time.Second))
 		MustSucceed(t, c.SetOption(mangos.OptionRecvDeadline, time.Second))
 
 		for i := 0; i < repeat; i++ {


### PR DESCRIPTION
After closing a req context, sometimes the pipe won't be re-added to the socket ready queue, which leaves the socket in an inoperable state. All subsequent sends will time out until something causes a new pipe to be attached. sendCtx can fail to reacquire the socket mutex (to release its pipe to the ready queue) until after its context is closed, resulting in the pipe getting dropped. ([Discussed here](https://github.com/nanomsg/mangos/issues/201#issuecomment-674368747)) 

* Close the context as part of the TestReqMultiContexts test to demonstrate the send/close race
* Add pipe back to ready queue after send unless the _socket_ is closed, rather than the _context_
