### PR TITLE
fixes #211 Want options for peer credential (IPC)

### DIFF
--- a/options.go
+++ b/options.go
@@ -192,4 +192,19 @@ const (
 	// Note that mangos v1 behavior is the same as if this option is
 	// set to true.
 	OptionDialAsynch = "DIAL-ASYNCH"
+
+	// OptionPeerPID is the peer process ID.  This is only implemented for
+	// transports that support it, and it is a read-only option for pipes
+	// only.  The value is an int.
+	OptionPeerPID = "PEER-PID"
+
+	// OptionPeerUID is the peer process user ID, typically obtained via
+	// SO_PEERCRED.  It is only available transports that support it, and is
+	// a read-only option for pipes.  The value of is an int.
+	OptionPeerUID = "PEER-UID"
+
+	// OptionPeerGID is the peer process group ID, typically obtained via
+	// SO_PEERCRED.  It is only available transports that support it, and is
+	// a read-only option for pipes.  The value of is an int.
+	OptionPeerGID = "PEER-GID"
 )

--- a/transport/connipc.go
+++ b/transport/connipc.go
@@ -1,0 +1,37 @@
+// Copyright 2020 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transport
+
+import (
+	"net"
+
+	"go.nanomsg.org/mangos/v3"
+)
+
+// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
+func NewConnPipeIPC(c net.Conn, proto ProtocolInfo) ConnPipe {
+	p := &connipc{
+		conn: conn{
+			c:       c,
+			proto:   proto,
+			options: make(map[string]interface{}),
+			maxrx:   0,
+		},
+	}
+	p.options[mangos.OptionMaxRecvSize] = 0
+	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
+	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
+	return p
+}

--- a/transport/connipc_posix.go
+++ b/transport/connipc_posix.go
@@ -1,6 +1,6 @@
 // +build !windows
 
-// Copyright 2019 The Mangos Authors
+// Copyright 2020 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -23,22 +23,6 @@ import (
 
 	"go.nanomsg.org/mangos/v3"
 )
-
-// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
-func NewConnPipeIPC(c net.Conn, proto ProtocolInfo) ConnPipe {
-	p := &connipc{
-		conn: conn{
-			c:       c,
-			proto:   proto,
-			options: make(map[string]interface{}),
-			maxrx:   0,
-		},
-	}
-	p.options[mangos.OptionMaxRecvSize] = 0
-	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
-	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
-	return p
-}
 
 func (p *connipc) Send(msg *Message) error {
 

--- a/transport/connipc_windows.go
+++ b/transport/connipc_windows.go
@@ -1,6 +1,6 @@
 // +build windows
 
-// Copyright 2019 The Mangos Authors
+// Copyright 2020 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -19,27 +19,9 @@ package transport
 import (
 	"encoding/binary"
 	"io"
-	"net"
 
 	"go.nanomsg.org/mangos/v3"
 )
-
-// NewConnPipeIPC allocates a new Pipe using the IPC exchange protocol.
-func NewConnPipeIPC(c net.Conn, proto ProtocolInfo) ConnPipe {
-	p := &connipc{
-		conn: conn{
-			c:       c,
-			proto:   proto,
-			options: make(map[string]interface{}),
-			maxrx:   0,
-		},
-	}
-	p.options[mangos.OptionMaxRecvSize] = 0
-	p.options[mangos.OptionLocalAddr] = c.LocalAddr()
-	p.options[mangos.OptionRemoteAddr] = c.RemoteAddr()
-
-	return p
-}
 
 func (p *connipc) Send(msg *Message) error {
 

--- a/transport/ipc/ipc_peer_linux.go
+++ b/transport/ipc/ipc_peer_linux.go
@@ -1,0 +1,40 @@
+// +build linux
+
+// Copyright 2020 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipc implements the IPC transport on top of UNIX domain sockets.
+// To enable it simply import it.
+package ipc
+
+import (
+	"net"
+	"syscall"
+
+	"go.nanomsg.org/mangos/v3"
+	"go.nanomsg.org/mangos/v3/transport"
+)
+
+func getPeer(c *net.UnixConn, pipe transport.ConnPipe) {
+	if sc, err := c.SyscallConn(); err == nil {
+		sc.Control(func(fd uintptr) {
+			uc, err := syscall.GetsockoptUcred(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+			if err == nil {
+				pipe.SetOption(mangos.OptionPeerPID, int(uc.Pid))
+				pipe.SetOption(mangos.OptionPeerUID, int(uc.Uid))
+				pipe.SetOption(mangos.OptionPeerGID, int(uc.Gid))
+			}
+		})
+	}
+}

--- a/transport/ipc/ipc_peer_unix.go
+++ b/transport/ipc/ipc_peer_unix.go
@@ -1,0 +1,27 @@
+// +build !linux,!windows,!plan9,!js
+
+// Copyright 2020 The Mangos Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use file except in compliance with the License.
+// You may obtain a copy of the license at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package ipc implements the IPC transport on top of UNIX domain sockets.
+// To enable it simply import it.
+package ipc
+
+import (
+	"go.nanomsg.org/mangos/v3/transport"
+	"net"
+)
+
+func getPeer(c *net.UnixConn, pipe transport.ConnPipe)  {
+}


### PR DESCRIPTION
This is a first work, and includes only support for Linux.  Still
that is likely to meet the needs of most users.  Additional
platform support may be added as we can test, or as the underlying
system libraries add the missing socket options or library calls.