### PR TITLE
fixes #198 negative send/receive deadlines do not work

### DIFF
--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -273,6 +273,8 @@ func (c *context) SendMsg(m *protocol.Message) error {
 			}
 			s.Unlock()
 		})
+	} else if c.sendExpire < 0 {
+		expired = true
 	}
 
 	s.send()
@@ -322,6 +324,10 @@ func (c *context) RecvMsg() (*protocol.Message, error) {
 	}
 
 	for id == c.reqID && c.repMsg == nil {
+		if c.recvExpire < 0 {
+			c.cancel()
+			return nil, protocol.ErrRecvTimeout
+		}
 		c.cond.Wait()
 	}
 

--- a/protocol/req/req_test.go
+++ b/protocol/req/req_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Mangos Authors
+// Copyright 2020 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -73,6 +73,22 @@ func TestReqRecvDeadline(t *testing.T) {
 	_ = MustRecv(t, peer)
 	m, e := self.RecvMsg()
 	MustBeError(t, e, mangos.ErrRecvTimeout)
+	MustBeNil(t, m)
+	MustSucceed(t, self.Close())
+	MustSucceed(t, peer.Close())
+}
+
+func TestReqRecvNonBlocking(t *testing.T) {
+	self := GetSocket(t, NewSocket)
+	peer := GetSocket(t, rep.NewSocket)
+	ConnectPair(t, self, peer)
+	MustSucceed(t, self.SetOption(mangos.OptionRecvDeadline, time.Duration(-1)))
+	MustSucceed(t, self.Send([]byte{}))
+	_ = MustRecv(t, peer)
+	start := time.Now()
+	m, e := self.RecvMsg()
+	MustBeError(t, e, mangos.ErrRecvTimeout)
+	MustBeTrue(t, time.Since(start) < time.Second)
 	MustBeNil(t, m)
 	MustSucceed(t, self.Close())
 	MustSucceed(t, peer.Close())
@@ -160,7 +176,20 @@ func TestReqBestEffort(t *testing.T) {
 	MustSucceed(t, s.SetOption(mangos.OptionBestEffort, false))
 	MustBeError(t, s.Send(msg), mangos.ErrSendTimeout)
 	MustBeError(t, s.Send(msg), mangos.ErrSendTimeout)
+	MustClose(t, s)
 }
+
+func TestReqSendNonBlocking(t *testing.T) {
+	timeout := -time.Millisecond
+	msg := []byte{'0', '1', '2', '3'}
+
+	s := GetSocket(t, NewSocket)
+	MustSucceed(t, s.SetOption(mangos.OptionSendDeadline, timeout))
+	MustSucceed(t, s.Listen(AddrTestInp()))
+	MustBeError(t, s.Send(msg), mangos.ErrSendTimeout)
+	MustClose(t, s)
+}
+
 
 // This test demonstrates cancellation before calling receive but after the
 // message is received causes the original message to be discarded.

--- a/protocol/surveyor/surveyor_test.go
+++ b/protocol/surveyor/surveyor_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Mangos Authors
+// Copyright 2020 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -176,6 +176,19 @@ func TestSurveyExpire(t *testing.T) {
 	MustBeNil(t, v)
 	MustSucceed(t, s.Close())
 }
+
+// This test demonstrates that surveys expire on their own.
+func TestSurveyRecvNonBlocking(t *testing.T) {
+	s := GetSocket(t, NewSocket)
+	MustSucceed(t, s.SetOption(mangos.OptionSurveyTime, time.Millisecond*10))
+	MustSucceed(t, s.SetOption(mangos.OptionRecvDeadline, time.Duration(-1)))
+	MustSucceed(t, s.Send([]byte("first")))
+	v, e := s.Recv()
+	MustBeError(t, e, mangos.ErrRecvTimeout)
+	MustBeNil(t, v)
+	MustClose(t, s)
+}
+
 
 // This test demonstrates that we can keep sending even if the pipes are full.
 func TestSurveyorBestEffortSend(t *testing.T) {

--- a/protocol/xpush/xpush.go
+++ b/protocol/xpush/xpush.go
@@ -72,7 +72,7 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 	tq := nilQ
 	if bestEffort {
 		tq = closedQ
-	} else if s.sendExpire > 0 {
+	} else if s.sendExpire != 0 {
 		tq = time.After(s.sendExpire)
 	}
 	if s.closed {
@@ -83,14 +83,18 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 
 	select {
 	case s.sendQ <- m:
-	case <-s.closeQ:
-		return protocol.ErrClosed
-	case <-tq:
-		if bestEffort {
-			m.Free()
-			return nil
+	default:
+		select {
+		case s.sendQ <- m:
+		case <-s.closeQ:
+			return protocol.ErrClosed
+		case <-tq:
+			if bestEffort {
+				m.Free()
+				return nil
+			}
+			return protocol.ErrSendTimeout
 		}
-		return protocol.ErrSendTimeout
 	}
 
 	s.Lock()


### PR DESCRIPTION
This actually affected pretty much all the protocols and both send
and receive deadlines.  While here we've also made sure that
a non-blocking check will not fail if a message can immediately
be sent or received.