### PR TITLE
fixes #213 Want options to set permissions on IPC socket

### DIFF
--- a/internal/test/addrs.go
+++ b/internal/test/addrs.go
@@ -16,6 +16,8 @@ package test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 )
@@ -31,10 +33,11 @@ func NextPort() uint32 {
 	return atomic.AddUint32(&currPort, 1)
 }
 
-// AddrTestIPC returns a test IPC address.  It will be in the current
+// AddrTestIPC returns a test IPC address.  It will be in the temporary
 // directory.
 func AddrTestIPC() string {
-	return (fmt.Sprintf("ipc://mangostest%d", NextPort()))
+	temp := filepath.ToSlash(os.TempDir())
+	return fmt.Sprintf("ipc://%s/mangostest%d", temp, NextPort())
 }
 
 // AddrTestWSS returns a websocket over TLS address.


### PR DESCRIPTION
This adds new options only available on UNIX systems to set
the permissions and ownership of the UNIX domain socket.
It also adds fixes to work better when testing with WSL
by forcing the sockets to be created in a temp dir.