### PR TITLE
fixes #224 Desire FastSendFailNoPeer option

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2021 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -43,4 +43,5 @@ const (
 	ErrNotRaw      = errors.ErrNotRaw
 	ErrCanceled    = errors.ErrCanceled
 	ErrNoContext   = errors.ErrNoContext
+	ErrNoPeers     = errors.ErrNoPeers
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2021 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -49,4 +49,5 @@ const (
 	ErrNotRaw      = err("socket not raw")
 	ErrCanceled    = err("operation canceled")
 	ErrNoContext   = err("protocol does not support contexts")
+	ErrNoPeers     = err("no connected peers")
 )

--- a/options.go
+++ b/options.go
@@ -214,4 +214,15 @@ const (
 	// Solaris platforms at present, and only when cgo support is enabled.
 	// The value is an int.
 	OptionPeerZone = "PEER-ZONE"
+
+	// OptionFailNoPeers causes send or receive operations to fail
+	// immediately rather than waiting for a timeout if there are no
+	// connected peers.  This helps discriminate between cases involving
+	// flow control, from those where we we have no peers.  Use of this
+	// option may make applications more brittle, as a temporary disconnect
+	// that may otherwise self-heal quickly will now create an immediate
+	// failure.  Applications using this should be prepared to deal with
+	// such failures.  Note that not all protocols respect this -- best
+	// effort protocols will particularly not support this.
+	OptionFailNoPeers = "FAIL-NO-PEERS"
 )

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Mangos Authors
+// Copyright 2021 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -67,6 +67,7 @@ const (
 	ErrProtoOp     = errors.ErrProtoOp
 	ErrProtoState  = errors.ErrProtoState
 	ErrCanceled    = errors.ErrCanceled
+	ErrNoPeers     = errors.ErrNoPeers
 )
 
 // Common option definitions
@@ -84,6 +85,7 @@ const (
 	OptionLinger       = mangos.OptionLinger // Remove?
 	OptionTTL          = mangos.OptionTTL
 	OptionBestEffort   = mangos.OptionBestEffort
+	OptionFailNoPeers  = mangos.OptionFailNoPeers
 )
 
 // MakeSocket creates a Socket on top of a Protocol.

--- a/protocol/push/push_test.go
+++ b/protocol/push/push_test.go
@@ -49,3 +49,11 @@ func TestPushOptions(t *testing.T) {
 func TestPushNoRecv(t *testing.T) {
 	CannotRecv(t, NewSocket)
 }
+
+func TestPushFastFailNoPeer(t *testing.T) {
+	VerifyOptionBool(t, NewSocket, mangos.OptionFailNoPeers)
+
+	s := GetSocket(t, NewSocket)
+	MustSucceed(t, s.SetOption(mangos.OptionFailNoPeers, true))
+	MustBeError(t, s.Send([]byte("junk")), mangos.ErrNoPeers)
+}


### PR DESCRIPTION
This introduces an option (for REQ and PUSH sockets to start) that allows these protocols to receive an ErrNoPeers error if they opt in with OptionFailNoPeers.   This error occurs when sending (or receiving in the case of REQ) when there are no peers.

Note that if this option is used with REQ sockets, the failure will occur even if the socket disconnects after send succeeds and before receive starts.  There are some possible warts -- for example if the peer disconnects and *reconnects* in the window, it's possible to receive a ProtocolState error.  Users of this capability should not depend too heavily on specific errors as changes in the connection graph can lead to surprises here.

Most callers should not use this option, and its entirely opt-in for now.