### PR TITLE
Req receive timeout timer appears to leak.

### DIFF
--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -1,4 +1,4 @@
-// Copyright 2021 The Mangos Authors
+// Copyright 2022 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -158,6 +158,10 @@ func (p *pipe) receiver() {
 			if c.resender != nil {
 				c.resender.Stop()
 				c.resender = nil
+			}
+			if c.recvTimer != nil {
+				c.recvTimer.Stop()
+				c.recvTimer = nil
 			}
 			c.cond.Broadcast()
 		} else {
@@ -498,12 +502,12 @@ func (s *socket) OpenContext() (protocol.Context, error) {
 		return nil, protocol.ErrClosed
 	}
 	c := &context{
-		s:          s,
-		cond:       sync.NewCond(s),
-		bestEffort: s.defCtx.bestEffort,
-		resendTime: s.defCtx.resendTime,
-		sendExpire: s.defCtx.sendExpire,
-		recvExpire: s.defCtx.recvExpire,
+		s:           s,
+		cond:        sync.NewCond(s),
+		bestEffort:  s.defCtx.bestEffort,
+		resendTime:  s.defCtx.resendTime,
+		sendExpire:  s.defCtx.sendExpire,
+		recvExpire:  s.defCtx.recvExpire,
 		failNoPeers: s.defCtx.failNoPeers,
 	}
 	s.ctxs[c] = struct{}{}


### PR DESCRIPTION
A lot of requests fired in succession potentially leave a lot
of timers running around in the background in the client.  This
should fix, although we should also (for performance reasons)
look at replacing the AfterFunc() semantic with a normal timer or
perhaps just using context.Context. (This code predates the existence
of Go standard contexts.)