### PR TITLE
Go 1.13 is too old.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,12 +5,15 @@ jobs:
   build:
     name: build
     runs-on: [ ubuntu-latest ]
+    strategy:
+      matrix:
+        go: [ '1.18', '1.17', '1.16', '1.15', '1.14', '1.13' ]
     steps:
 
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: ${{ matrix.go }}
       id: go
 
     - name: Go version

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.13
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory

--- a/macat/macat_test.go
+++ b/macat/macat_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 The Mangos Authors
+// Copyright 2022 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use file except in compliance with the License.
@@ -214,7 +214,7 @@ func TestApp_Run8(t *testing.T) {
 	a := &App{}
 	a.Initialize()
 	addr := AddrTestIPC()
-	path := strings.TrimPrefix(addr, "ipc://")
+	ipcPath := strings.TrimPrefix(addr, "ipc://")
 	rx := GetSocket(t, req.NewSocket)
 	defer MustClose(t, rx)
 
@@ -224,7 +224,7 @@ func TestApp_Run8(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		a.stdOut = b
-		e := a.Run("--rep", "-X", path, "-A", "--data", "pong", "--send-timeout", "2", "--recv-timeout", "2")
+		e := a.Run("--rep", "-X", ipcPath, "-A", "--data", "pong", "--send-timeout", "2", "--recv-timeout", "2")
 		MustFailLike(t, e, mangos.ErrClosed.Error())
 	}()
 	time.Sleep(time.Millisecond * 20)
@@ -247,7 +247,7 @@ func TestApp_Ipc(t *testing.T) {
 	defer MustClose(t, rx)
 	MustSucceed(t, rx.SetOption(mangos.OptionRecvDeadline, time.Millisecond*40))
 	addr := AddrTestIPC()
-	path := strings.TrimPrefix(addr, "ipc://")
+	ipcPath := strings.TrimPrefix(addr, "ipc://")
 
 	b := &strings.Builder{}
 	var wg sync.WaitGroup
@@ -256,7 +256,7 @@ func TestApp_Ipc(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		a.stdOut = b
-		_ = a.Run("--rep", "-x", path, "-A", "--recv-timeout", "2")
+		_ = a.Run("--rep", "-x", ipcPath, "-A", "--recv-timeout", "2")
 	}()
 	time.Sleep(time.Millisecond * 20)
 	MustSendString(t, rx, "query")
@@ -1062,9 +1062,9 @@ func TestApp_TLS_Dup_CA(t *testing.T) {
 	keyfile := path.Join(dir, "key.pem")
 	crtfile := path.Join(dir, "cert.pem")
 
-	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM, 0644))
+	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM(), 0644))
 	addr := AddrTestTLS()
 
 	a := &App{}
@@ -1086,9 +1086,9 @@ func TestApp_Dial_TLS(t *testing.T) {
 	keyfile := path.Join(dir, "key.pem")
 	crtfile := path.Join(dir, "cert.pem")
 
-	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM, 0644))
+	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM(), 0644))
 	addr := AddrTestTLS()
 	opts := make(map[string]interface{})
 	opts[mangos.OptionTLSConfig] = cfg
@@ -1124,9 +1124,9 @@ func TestApp_Dial_TLS_Insecure(t *testing.T) {
 	keyfile := path.Join(dir, "key.pem")
 	crtfile := path.Join(dir, "cert.pem")
 
-	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM, 0644))
+	MustSucceed(t, ioutil.WriteFile(cafile, keys.Root.CertPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Client.KeyPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Client.CertPEM(), 0644))
 	addr := AddrTestTLS()
 	opts := make(map[string]interface{})
 	opts[mangos.OptionTLSConfig] = cfg
@@ -1186,8 +1186,8 @@ func TestApp_Bind_TLS(t *testing.T) {
 	keyfile := path.Join(dir, "key.pem")
 	crtfile := path.Join(dir, "cert.pem")
 
-	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Server.KeyPEM, 0644))
-	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Server.CertPEM, 0644))
+	MustSucceed(t, ioutil.WriteFile(keyfile, keys.Server.KeyPEM(), 0644))
+	MustSucceed(t, ioutil.WriteFile(crtfile, keys.Server.CertPEM(), 0644))
 	addr := AddrTestTLS()
 	opts := make(map[string]interface{})
 	opts[mangos.OptionTLSConfig] = cfg

--- a/test/certs.go
+++ b/test/certs.go
@@ -27,14 +27,11 @@ import (
 )
 
 type key struct {
-	pubKey ed25519.PublicKey
-	prvKey ed25519.PrivateKey
-	keyPEM []byte
-
+	pubKey  ed25519.PublicKey
+	prvKey  ed25519.PrivateKey
 	cert    *x509.Certificate
 	certDER []byte
-
-	pair tls.Certificate
+	pair    tls.Certificate
 }
 
 type keys struct {


### PR DESCRIPTION
We need to test with more recent Go versions on Windows and
Darwin.  Additionally, we really would like to matrix test
things on Linux (which runs faster because of more resources
that are available) across a matrix of Go versions.

The matrix currently includes Go 1.13 through Go 1.18.  At
some point in the near future we will be pruning back on
support commitments for older Go versions.