### PR TITLE
Fix TLS configuration check in tlstcp transport

### DIFF
--- a/transport/tlstcp/tlstcp.go
+++ b/transport/tlstcp/tlstcp.go
@@ -153,7 +153,7 @@ func (l *listener) Listen() error {
 	if config == nil {
 		return mangos.ErrTLSNoConfig
 	}
-	if config.Certificates == nil || len(config.Certificates) == 0 {
+	if config.GetCertificate == nil && (config.Certificates == nil || len(config.Certificates) == 0) {
 		l.lock.Unlock()
 		return mangos.ErrTLSNoCert
 	}


### PR DESCRIPTION
Updated the certificate validation to account for GetCertificate being nil alongside existing certificate checks. This ensures proper error handling during TLS configuration setup.

Fixes #316