### PR TITLE
Use "stable" and "oldstable", and formally declare our support for Go…

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,7 +1,6 @@
 name: coverage
 on: [push]
 jobs:
-
   build:
     name: build
     runs-on: ${{ matrix.os }}
@@ -9,30 +8,29 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "stable"
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: '1.22'
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Get dependencies
+        run: go get -v -t -d ./...
 
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+      - name: Build
+        run: go build -v .
 
-    - name: Build
-      run: go build -v .
+      - name: Test
+        run: go test -coverpkg="go.nanomsg.org/mangos/v3/..." -covermode=count -coverprofile="coverage.txt" ./...
 
-    - name: Test
-      run: go test -coverpkg="go.nanomsg.org/mangos/v3/..." -covermode=count -coverprofile="coverage.txt" ./...
-
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5.4.3
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.txt
-        flags: unittests
-        name: codecov-umbrella
-        yml: ./codecov.yml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.txt
+          flags: unittests
+          name: codecov-umbrella
+          yml: ./codecov.yml

--- a/.github/workflows/darwin.yml
+++ b/.github/workflows/darwin.yml
@@ -1,30 +1,27 @@
 name: darwin
 on: [push]
 jobs:
-
   build:
     name: build
-    runs-on: [ macos-latest ]
-    steps:
+    runs-on: [macos-latest]
     strategy:
       matrix:
-        go: [ '1.22', '1.20', '1.16' ]
+        go: ["stable", "oldstable"]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Get dependencies
+        run: go get -v -t -d ./...
 
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+      - name: Build
+        run: go build -v .
 
-    - name: Build
-      run: go build -v .
-
-    - name: Test
-      run: go test ./...
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,32 +1,30 @@
 name: linux
 on: [push]
 jobs:
-
   build:
     name: build
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ubuntu-latest]
     strategy:
       matrix:
-        go: [ '1.22', '1.21', '1.20', '1.18', '1.17', '1.16' ]
+        go: ["stable", "oldstable"]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
+      - name: Go version
+        run: go version
 
-    - name: Go version
-      run: go version
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Get dependencies
+        run: go get -v -t -d ./...
 
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+      - name: Build
+        run: go build -v .
 
-    - name: Build
-      run: go build -v .
-
-    - name: Test
-      run: go test ./...
+      - name: Test
+        run: go test ./...

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,29 +1,27 @@
 name: windows
 on: [push]
 jobs:
-
   build:
     name: build
-    runs-on: [ windows-latest ]
+    runs-on: [windows-latest]
     strategy:
       matrix:
-        go: [ '1.22', '1.21', '1.20', '1.18' ]
+        go: ["stable", "oldstable"]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go }}
+        id: go
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go }}
-      id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Get dependencies
+        run: go get -v -t -d ./...
 
-    - name: Get dependencies
-      run: go get -v -t -d ./...
+      - name: Build
+        run: go build -v .
 
-    - name: Build
-      run: go build -v .
-
-    - name: Test
-      run: go test ./...
+      - name: Test
+        run: go test ./...

--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ There are also internal benchmarks available:
 [Staysail Systems, Inc.](mailto:info@staysail.tech) offers
 [commercial support](http://staysail.tech/support/mangos) for mangos.
 
+## Compatibility
+
+Mangos should run on any reasonable platform, but we officially follow
+the same support matrix as Go - meaning only the most recent release of Go, and
+the release preceding it are guaranteed support.  Having said that, we generally
+will attempt not to break earlier versions of Go intentionally.
+
+As of this writing, Go versions before 1.22 are not supported (because of dependency
+requirements).
+
 ## Examples
 
 Some examples are posted in the directories under `examples/` in this project.
@@ -84,6 +94,6 @@ Enjoy!
 
 ---
 
-Copyright 2021 The Mangos Authors
+Copyright 2025 The Mangos Authors
 
 mangos&trade;, Nanomsg&trade; and NNG&trade; are [trademarks](http://nanomsg.org/trademarks.html) of Garrett D'Amore.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,4 @@ require (
 
 require golang.org/x/sys v0.10.0 // indirect
 
-go 1.21
-
-toolchain go1.22.0
+go 1.22


### PR DESCRIPTION
… versions.

We need to follow the same go version commitments so that we can adopt new Go APIs, but mostly also so that we can include updated dependencies which may be necessary to fix security bugs.