### PR TITLE
Add Context variants for Send and Receive

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -22,5 +22,4 @@
 // Surveyor/Respondent, etc.
 //
 // For more information, see www.nanomsg.org.
-//
 package mangos

--- a/examples/bus/bus.go
+++ b/examples/bus/bus.go
@@ -16,18 +16,17 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url0=tcp://127.0.0.1:40890
-//   $ url1=tcp://127.0.0.1:40891
-//   $ url2=tcp://127.0.0.1:40892
-//   $ url3=tcp://127.0.0.1:40893
-//   $ ./bus node0 $url0 $url1 $url2 & node0=$!
-//   $ ./bus node1 $url1 $url2 $url3 & node1=$!
-//   $ ./bus node2 $url2 $url3 & node2=$!
-//   $ ./bus node3 $url3 $url0 & node3=$!
-//   $ sleep 5
-//   $ kill $node0 $node1 $node2 $node3
-//
+//	$ go build .
+//	$ url0=tcp://127.0.0.1:40890
+//	$ url1=tcp://127.0.0.1:40891
+//	$ url2=tcp://127.0.0.1:40892
+//	$ url3=tcp://127.0.0.1:40893
+//	$ ./bus node0 $url0 $url1 $url2 & node0=$!
+//	$ ./bus node1 $url1 $url2 $url3 & node1=$!
+//	$ ./bus node2 $url2 $url3 & node2=$!
+//	$ ./bus node3 $url3 $url0 & node3=$!
+//	$ sleep 5
+//	$ kill $node0 $node1 $node2 $node3
 package main
 
 import (

--- a/examples/context/context.go
+++ b/examples/context/context.go
@@ -20,18 +20,17 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $
-//   $ ./context server $url & server=$! && sleep 1
-//   $ ./context client $url "John"
-//   $ ./context client $url "Bill"
-//   $ ./context client $url "Mary"
-//   $ ./context client $url "Susan"
-//   $ ./context client $url "Mark"
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$
+//	$ ./context server $url & server=$! && sleep 1
+//	$ ./context client $url "John"
+//	$ ./context client $url "Bill"
+//	$ ./context client $url "Mary"
+//	$ ./context client $url "Susan"
+//	$ ./context client $url "Mark"
 //
-//   $ kill $server
-//
+//	$ kill $server
 package main
 
 import (
@@ -53,7 +52,8 @@ func die(format string, v ...interface{}) {
 	os.Exit(1)
 }
 
-/**
+/*
+*
 This function will act as the server. It will create a single REP socket and a pool of worker go routines that will
 simultaneously service requests from many clients. This means that two clients can both send a request to the
 server and the server can deal with both of them concurrently. The server does not need to

--- a/examples/pair/pair.go
+++ b/examples/pair/pair.go
@@ -17,13 +17,12 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ ./pair node0 $url & node0=$!
-//   $ ./pair node1 $url & node1=$!
-//   $ sleep 3
-//   $ kill $node0 $node1
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ ./pair node0 $url & node0=$!
+//	$ ./pair node1 $url & node1=$!
+//	$ sleep 3
+//	$ kill $node0 $node1
 package main
 
 import (

--- a/examples/pipeline/pipeline.go
+++ b/examples/pipeline/pipeline.go
@@ -17,13 +17,12 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ ./pipeline node0 $url & node0=$! && sleep 1
-//   $ ./pipeline node1 $url "Hello, World."
-//   $ ./pipeline node1 $url "Goodbye."
-//   $ kill $node0
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ ./pipeline node0 $url & node0=$! && sleep 1
+//	$ ./pipeline node1 $url "Hello, World."
+//	$ ./pipeline node1 $url "Goodbye."
+//	$ kill $node0
 package main
 
 import (

--- a/examples/pubsub/pubsub.go
+++ b/examples/pubsub/pubsub.go
@@ -17,15 +17,14 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ ./pubsub server $url server & server=$! && sleep 1
-//   $ ./pubsub client $url client0 & client0=$!
-//   $ ./pubsub client $url client1 & client1=$!
-//   $ ./pubsub client $url client2 & client2=$!
-//   $ sleep 5
-//   $ kill $server $client0 $client1 $client2
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ ./pubsub server $url server & server=$! && sleep 1
+//	$ ./pubsub client $url client0 & client0=$!
+//	$ ./pubsub client $url client1 & client1=$!
+//	$ ./pubsub client $url client2 & client2=$!
+//	$ sleep 5
+//	$ kill $server $client0 $client1 $client2
 package main
 
 import (

--- a/examples/raw/main.go
+++ b/examples/raw/main.go
@@ -18,14 +18,13 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ nservers=20
-//   $ nclients=10
-//   $ ./raw server $url $nservers & pid=$! && sleep 1
-//   $ ./raw client $url $nclients
-//   $ kill $pid
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ nservers=20
+//	$ nclients=10
+//	$ ./raw server $url $nservers & pid=$! && sleep 1
+//	$ ./raw client $url $nclients
+//	$ kill $pid
 package main
 
 import (

--- a/examples/reqrep/reqrep.go
+++ b/examples/reqrep/reqrep.go
@@ -17,12 +17,11 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ ./reqrep node0 $url & node0=$! && sleep 1
-//   $ ./reqrep node1 $url
-//   $ kill $node0
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ ./reqrep node0 $url & node0=$! && sleep 1
+//	$ ./reqrep node1 $url
+//	$ kill $node0
 package main
 
 import (

--- a/examples/survey/survey.go
+++ b/examples/survey/survey.go
@@ -17,15 +17,14 @@
 //
 // To use:
 //
-//   $ go build .
-//   $ url=tcp://127.0.0.1:40899
-//   $ ./survey server $url server & server=$!
-//   $ ./survey client $url client0 & client0=$!
-//   $ ./survey client $url client1 & client1=$!
-//   $ ./survey client $url client2 & client2=$!
-//   $ sleep 5
-//   $ kill $server $client0 $client1 $client2
-//
+//	$ go build .
+//	$ url=tcp://127.0.0.1:40899
+//	$ ./survey server $url server & server=$!
+//	$ ./survey client $url client0 & client0=$!
+//	$ ./survey client $url client1 & client1=$!
+//	$ ./survey client $url client2 & client2=$!
+//	$ sleep 5
+//	$ kill $server $client0 $client1 $client2
 package main
 
 import (

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -17,20 +17,19 @@
 //
 // The server listens, and offers three paths:
 //
-//  - sub/    - SUB socket, publishes a message "PUB <count> <time>" each second
-//  - req/    - REQ socket, responds with a reply "REPLY <count> <time>"
-//  - static/ - static content, provided as ASCII "STATIC"
+//   - sub/    - SUB socket, publishes a message "PUB <count> <time>" each second
+//   - req/    - REQ socket, responds with a reply "REPLY <count> <time>"
+//   - static/ - static content, provided as ASCII "STATIC"
 //
 // To use:
 //
-//   $ go build .
-//   $ port=40899
-//   $ ./websocket server port & pid=$! && sleep 1
-//   $ ./websocket req $port
-//   $ ./websocket sub $port
-//   $ ./websocket static $port
-//   $ kill $pid
-//
+//	$ go build .
+//	$ port=40899
+//	$ ./websocket server port & pid=$! && sleep 1
+//	$ ./websocket req $port
+//	$ ./websocket sub $port
+//	$ ./websocket static $port
+//	$ kill $pid
 package main
 
 import (

--- a/protocol.go
+++ b/protocol.go
@@ -14,6 +14,8 @@
 
 package mangos
 
+import "context"
+
 // ProtocolPipe represents the handle that a Protocol implementation has
 // to the underlying stream transport.  It can be thought of as one side
 // of a TCP, IPC, or other type of connection.
@@ -66,6 +68,15 @@ type ProtocolContext interface {
 	// RecvMsg receives a complete message, including the message header,
 	// which is useful for protocols in raw mode.
 	RecvMsg() (*Message, error)
+
+	// RecvMsgContext receives a complete message, including the message header.
+	// It will block until a message is received, the context is canceled, or
+	// the context deadline expires.
+	RecvMsgContext(context.Context) (*Message, error)
+
+	// SendMsgContext sends a message. It will block until the message can be
+	// queued, the context is canceled, or the context deadline expires.
+	SendMsgContext(context.Context, *Message) error
 
 	// GetOption is used to retrieve the current value of an option.
 	// If the protocol doesn't recognize the option, EBadOption should

--- a/protocol/bus/bus.go
+++ b/protocol/bus/bus.go
@@ -17,6 +17,8 @@
 package bus
 
 import (
+	"context"
+
 	"go.nanomsg.org/mangos/v3/protocol"
 	"go.nanomsg.org/mangos/v3/protocol/xbus"
 )
@@ -41,20 +43,28 @@ func (s *socket) GetOption(name string) (interface{}, error) {
 	return s.Protocol.GetOption(name)
 }
 
+func (s *socket) SendMsg(m *protocol.Message) error {
+	return s.SendMsgContext(context.Background(), m)
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
+	if len(m.Header) > 0 {
+		m.Header = m.Header[:0]
+	}
+	return s.Protocol.SendMsgContext(ctx, m)
+}
+
 func (s *socket) RecvMsg() (*protocol.Message, error) {
-	m, e := s.Protocol.RecvMsg()
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	m, e := s.Protocol.RecvMsgContext(ctx)
 	if m != nil {
 		// Strip the raw mode header, as we don't use it in cooked mode
 		m.Header = m.Header[:0]
 	}
 	return m, e
-}
-
-func (s *socket) SendMsg(m *protocol.Message) error {
-	if len(m.Header) > 0 {
-		m.Header = m.Header[:0]
-	}
-	return s.Protocol.SendMsg(m)
 }
 
 // NewProtocol returns a new protocol implementation.

--- a/protocol/pair1/pair1.go
+++ b/protocol/pair1/pair1.go
@@ -18,6 +18,8 @@
 package pair1
 
 import (
+	"context"
+
 	"go.nanomsg.org/mangos/v3/protocol"
 	"go.nanomsg.org/mangos/v3/protocol/xpair1"
 )
@@ -43,8 +45,12 @@ func (s *socket) GetOption(name string) (interface{}, error) {
 }
 
 func (s *socket) SendMsg(m *protocol.Message) error {
+	return s.SendMsgContext(context.Background(), m)
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
 	m.Header = make([]byte, 4)
-	err := s.Protocol.SendMsg(m)
+	err := s.Protocol.SendMsgContext(ctx, m)
 	if err != nil {
 		m.Header = m.Header[:0]
 	}
@@ -52,7 +58,11 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {
-	m, err := s.Protocol.RecvMsg()
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	m, err := s.Protocol.RecvMsgContext(ctx)
 	if err == nil && m != nil {
 		m.Header = m.Header[:0]
 	}

--- a/protocol/req/req.go
+++ b/protocol/req/req.go
@@ -67,11 +67,11 @@ type socket struct {
 	defCtx   *reqContext              // default context
 	contexts map[*reqContext]struct{} // all contexts (set)
 	ctxByID  map[uint32]*reqContext   // contexts by request ID
-	nextID   uint32                // next request ID
-	closed   bool                  // true if we are closed
+	nextID   uint32                   // next request ID
+	closed   bool                     // true if we are closed
 	sendQ    []*reqContext            // contexts waiting to send
-	readyQ   []*pipe               // pipes available for sending
-	pipes    map[uint32]*pipe      // all pipes
+	readyQ   []*pipe                  // pipes available for sending
+	pipes    map[uint32]*pipe         // all pipes
 }
 
 func (s *socket) send() {

--- a/protocol/req/req_test.go
+++ b/protocol/req/req_test.go
@@ -494,7 +494,6 @@ func TestReqSendNoPeerDisconnect(t *testing.T) {
 	MustSucceed(t, s.Close())
 }
 
-
 func TestReqRecvNoPeer(t *testing.T) {
 	VerifyOptionBool(t, NewSocket, mangos.OptionFailNoPeers)
 
@@ -511,7 +510,7 @@ func TestReqRecvNoPeer(t *testing.T) {
 	MustSucceed(t, s.Send([]byte("one"))) // sent by the socket, picked up by rep socket
 	time.Sleep(time.Millisecond * 20)
 	MustSucceed(t, p.Close())
-	time.Sleep(time.Millisecond*20)
+	time.Sleep(time.Millisecond * 20)
 	MustNotRecv(t, s, mangos.ErrNoPeers)
 	MustSucceed(t, s.Close())
 }
@@ -531,7 +530,7 @@ func TestReqRecvNoPeerDisconnect(t *testing.T) {
 	time.Sleep(time.Millisecond * 20)
 	MustSucceed(t, s.Send([]byte("one"))) // sent by the socket, picked up by rep socket
 	go func() {
-		time.Sleep(time.Millisecond*10)
+		time.Sleep(time.Millisecond * 10)
 		MustSucceed(t, p.Close())
 	}()
 	MustNotRecv(t, s, mangos.ErrNoPeers)

--- a/protocol/star/star.go
+++ b/protocol/star/star.go
@@ -22,6 +22,8 @@
 package star
 
 import (
+	"context"
+
 	"go.nanomsg.org/mangos/v3/protocol"
 	"go.nanomsg.org/mangos/v3/protocol/xstar"
 )
@@ -47,8 +49,12 @@ func (s *socket) GetOption(name string) (interface{}, error) {
 }
 
 func (s *socket) SendMsg(m *protocol.Message) error {
+	return s.SendMsgContext(context.Background(), m)
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
 	m.Header = make([]byte, 4)
-	err := s.Protocol.SendMsg(m)
+	err := s.Protocol.SendMsgContext(ctx, m)
 	if err != nil {
 		m.Header = m.Header[:0]
 	}
@@ -56,7 +62,11 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {
-	m, err := s.Protocol.RecvMsg()
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	m, err := s.Protocol.RecvMsgContext(ctx)
 	if err == nil && m != nil {
 		m.Header = m.Header[:0]
 	}

--- a/protocol/surveyor/surveyor.go
+++ b/protocol/surveyor/surveyor.go
@@ -69,14 +69,13 @@ type surveyorContext struct {
 type socket struct {
 	master   *surveyorContext              // default context
 	ctxs     map[*surveyorContext]struct{} // all contexts
-	surveys  map[uint32]*survey    // contexts by survey ID
-	pipes    map[uint32]*pipe      // all pipes by pipe ID
-	nextID   uint32                // next survey ID
-	closed   bool                  // true if closed
-	sendQLen int                   // send Q depth
+	surveys  map[uint32]*survey            // contexts by survey ID
+	pipes    map[uint32]*pipe              // all pipes by pipe ID
+	nextID   uint32                        // next survey ID
+	closed   bool                          // true if closed
+	sendQLen int                           // send Q depth
 	sync.Mutex
 }
-
 
 func (s *survey) cancel(err error) {
 

--- a/protocol/surveyor/surveyor.go
+++ b/protocol/surveyor/surveyor.go
@@ -17,7 +17,9 @@
 package surveyor
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -34,6 +36,7 @@ const (
 )
 
 const defaultSurveyTime = time.Second
+const defaultQLen = 128
 
 type pipe struct {
 	s      *socket
@@ -47,13 +50,13 @@ type survey struct {
 	recvQ  chan *protocol.Message
 	active bool
 	id     uint32
-	ctx    *context
+	ctx    *surveyorContext
 	sock   *socket
 	err    error
 	once   sync.Once
 }
 
-type context struct {
+type surveyorContext struct {
 	s          *socket
 	closed     bool
 	closeQ     chan struct{}
@@ -64,8 +67,8 @@ type context struct {
 }
 
 type socket struct {
-	master   *context              // default context
-	ctxs     map[*context]struct{} // all contexts
+	master   *surveyorContext              // default context
+	ctxs     map[*surveyorContext]struct{} // all contexts
 	surveys  map[uint32]*survey    // contexts by survey ID
 	pipes    map[uint32]*pipe      // all pipes by pipe ID
 	nextID   uint32                // next survey ID
@@ -74,11 +77,6 @@ type socket struct {
 	sync.Mutex
 }
 
-var (
-	nilQ <-chan time.Time
-)
-
-const defaultQLen = 128
 
 func (s *survey) cancel(err error) {
 
@@ -115,7 +113,7 @@ func (s *survey) start(qLen int, expire time.Duration) {
 	})
 }
 
-func (c *context) SendMsg(m *protocol.Message) error {
+func (c *surveyorContext) SendMsgContext(ctx context.Context, m *protocol.Message) error {
 	s := c.s
 
 	newsurv := &survey{
@@ -158,7 +156,11 @@ func (c *context) SendMsg(m *protocol.Message) error {
 	return nil
 }
 
-func (c *context) RecvMsg() (*protocol.Message, error) {
+func (c *surveyorContext) SendMsg(m *protocol.Message) error {
+	return c.SendMsgContext(context.Background(), m)
+}
+
+func (c *surveyorContext) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
 	s := c.s
 
 	s.Lock()
@@ -167,10 +169,6 @@ func (c *context) RecvMsg() (*protocol.Message, error) {
 		return nil, protocol.ErrClosed
 	}
 	surv := c.surv
-	timeq := nilQ
-	if c.recvExpire > 0 {
-		timeq = time.After(c.recvExpire)
-	}
 	s.Unlock()
 
 	if surv == nil {
@@ -188,12 +186,26 @@ func (c *context) RecvMsg() (*protocol.Message, error) {
 		}
 		return m, nil
 
-	case <-timeq:
-		return nil, protocol.ErrRecvTimeout
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return nil, protocol.ErrRecvTimeout
+		}
+		return nil, ctx.Err()
 	}
 }
 
-func (c *context) close() {
+func (c *surveyorContext) RecvMsg() (*protocol.Message, error) {
+	ctx := context.Background()
+	if c.recvExpire > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.recvExpire)
+		defer cancel()
+	}
+
+	return c.RecvMsgContext(ctx)
+}
+
+func (c *surveyorContext) close() {
 	if !c.closed {
 		c.closed = true
 		close(c.closeQ)
@@ -204,7 +216,7 @@ func (c *context) close() {
 	}
 }
 
-func (c *context) Close() error {
+func (c *surveyorContext) Close() error {
 	c.s.Lock()
 	defer c.s.Unlock()
 	if c.closed {
@@ -214,7 +226,7 @@ func (c *context) Close() error {
 	return nil
 }
 
-func (c *context) SetOption(name string, value interface{}) error {
+func (c *surveyorContext) SetOption(name string, value interface{}) error {
 	switch name {
 	case protocol.OptionSurveyTime:
 		if v, ok := value.(time.Duration); ok {
@@ -248,7 +260,7 @@ func (c *context) SetOption(name string, value interface{}) error {
 	return protocol.ErrBadOption
 }
 
-func (c *context) GetOption(option string) (interface{}, error) {
+func (c *surveyorContext) GetOption(option string) (interface{}, error) {
 	switch option {
 	case protocol.OptionSurveyTime:
 		c.s.Lock()
@@ -330,7 +342,7 @@ func (s *socket) OpenContext() (protocol.Context, error) {
 	if s.closed {
 		return nil, protocol.ErrClosed
 	}
-	c := &context{
+	c := &surveyorContext{
 		s:          s,
 		closeQ:     make(chan struct{}),
 		survExpire: s.master.survExpire,
@@ -341,8 +353,16 @@ func (s *socket) OpenContext() (protocol.Context, error) {
 	return c, nil
 }
 
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
+	return s.master.SendMsgContext(ctx, m)
+}
+
 func (s *socket) SendMsg(m *protocol.Message) error {
 	return s.master.SendMsg(m)
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	return s.master.RecvMsgContext(ctx)
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {
@@ -433,11 +453,11 @@ func NewProtocol() protocol.Protocol {
 	s := &socket{
 		pipes:    make(map[uint32]*pipe),
 		surveys:  make(map[uint32]*survey),
-		ctxs:     make(map[*context]struct{}),
+		ctxs:     make(map[*surveyorContext]struct{}),
 		sendQLen: defaultQLen,
 		nextID:   uint32(time.Now().UnixNano()), // quasi-random
 	}
-	s.master = &context{
+	s.master = &surveyorContext{
 		s:          s,
 		closeQ:     make(chan struct{}),
 		recvQLen:   defaultQLen,
@@ -447,7 +467,7 @@ func NewProtocol() protocol.Protocol {
 	return s
 }
 
-// NewSocket allocates a new Socket using the RESPONDENT protocol.
+// NewSocket allocates a new Socket using the SURVEYOR protocol.
 func NewSocket() (protocol.Socket, error) {
 	return protocol.MakeSocket(NewProtocol()), nil
 }

--- a/protocol/xpair/xpair.go
+++ b/protocol/xpair/xpair.go
@@ -17,6 +17,8 @@
 package xpair
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -65,57 +67,92 @@ func init() {
 const defaultQLen = 128
 
 func (s *socket) SendMsg(m *protocol.Message) error {
-	timeQ := nilQ
+	return s.SendMsgContext(context.Background(), m)
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
 	s.Lock()
 	if s.closed {
 		s.Unlock()
 		return protocol.ErrClosed
 	}
-	if s.bestEffort {
-		timeQ = closedQ
-	} else if s.sendExpire > 0 {
-		timeQ = time.After(s.sendExpire)
-	}
+	sendExpire := s.sendExpire
+	bestEffort := s.bestEffort
 	sizeQ := s.sizeQ
 	sendQ := s.sendQ
 	closeQ := s.closeQ
 	s.Unlock()
 
-	select {
-	case <-closeQ:
-		return protocol.ErrClosed
-	case <-timeQ:
-		if timeQ == closedQ {
+	// Apply timeout if configured and no deadline already set
+	if sendExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, sendExpire)
+			defer cancel()
+		}
+	}
+
+	if bestEffort {
+		select {
+		case sendQ <- m:
+			return nil
+		case <-sizeQ:
+			m.Free()
+			return nil
+		default:
 			m.Free()
 			return nil
 		}
-		return protocol.ErrSendTimeout
+	}
 
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return protocol.ErrSendTimeout
+		}
+		return ctx.Err()
+	case <-closeQ:
+		return protocol.ErrClosed
 	case <-sizeQ:
 		m.Free()
 		return nil
-
 	case sendQ <- m:
 		return nil
 	}
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {
-	for {
-		timeQ := nilQ
-		s.Lock()
-		if s.recvExpire > 0 {
-			timeQ = time.After(s.recvExpire)
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	s.Lock()
+	recvExpire := s.recvExpire
+	s.Unlock()
+
+	// Apply timeout if configured and no deadline already set
+	if recvExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, recvExpire)
+			defer cancel()
 		}
+	}
+
+	for {
+		s.Lock()
 		closeQ := s.closeQ
 		recvQ := s.recvQ
 		sizeQ := s.sizeQ
 		s.Unlock()
 		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, protocol.ErrRecvTimeout
+			}
+			return nil, ctx.Err()
 		case <-closeQ:
 			return nil, protocol.ErrClosed
-		case <-timeQ:
-			return nil, protocol.ErrRecvTimeout
 		case m := <-recvQ:
 			return m, nil
 		case <-sizeQ:

--- a/protocol/xpub/xpub.go
+++ b/protocol/xpub/xpub.go
@@ -17,6 +17,7 @@
 package xpub
 
 import (
+	"context"
 	"sync"
 
 	"go.nanomsg.org/mangos/v3/protocol"
@@ -65,6 +66,14 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 	s.Unlock()
 	m.Free()
 	return nil
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
+	return s.SendMsg(m)
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	return s.RecvMsg()
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {

--- a/protocol/xpush/xpush.go
+++ b/protocol/xpush/xpush.go
@@ -283,7 +283,7 @@ func (s *socket) Close() error {
 		return protocol.ErrClosed
 	}
 	s.closed = true
-	s.cv.Broadcast() 
+	s.cv.Broadcast()
 	s.Unlock()
 	close(s.closeQ)
 	return nil
@@ -346,7 +346,7 @@ func (*socket) Info() protocol.Info {
 func NewProtocol() protocol.Protocol {
 	s := &socket{
 		closeQ:   make(chan struct{}),
-		noPeerQ: make(chan struct{}),
+		noPeerQ:  make(chan struct{}),
 		sendQ:    make(chan *protocol.Message, defaultQLen),
 		sendQLen: defaultQLen,
 		pipes:    make(map[uint32]*pipe),

--- a/protocol/xpush/xpush.go
+++ b/protocol/xpush/xpush.go
@@ -16,6 +16,8 @@
 package xpush
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -70,43 +72,7 @@ func init() {
 // ID at the end of the header, plus any leading backtrace information
 // coming from a paired REP socket.
 func (s *socket) SendMsg(m *protocol.Message) error {
-	s.Lock()
-	bestEffort := s.bestEffort
-	tq := nilQ
-	if bestEffort {
-		tq = closedQ
-	} else if s.sendExpire > 0 {
-		tq = time.After(s.sendExpire)
-	}
-	if s.closed {
-		s.Unlock()
-		return protocol.ErrClosed
-	}
-	if s.failNoPeers && len(s.pipes) == 0 {
-		s.Unlock()
-		return protocol.ErrNoPeers
-	}
-	pq := s.noPeerQ
-	s.Unlock()
-
-	select {
-	case <-pq:
-		return protocol.ErrNoPeers
-	case s.sendQ <- m:
-	case <-s.closeQ:
-		return protocol.ErrClosed
-	case <-tq:
-		if bestEffort {
-			m.Free()
-			return nil
-		}
-		return protocol.ErrSendTimeout
-	}
-
-	s.Lock()
-	s.cv.Signal()
-	s.Unlock()
-	return nil
+	return s.SendMsgContext(context.Background(), m)
 }
 
 func (s *socket) sender() {
@@ -125,6 +91,62 @@ func (s *socket) sender() {
 		s.readyQ = s.readyQ[1:]
 		go p.send(m)
 	}
+}
+
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
+	s.Lock()
+	sendExpire := s.sendExpire
+	bestEffort := s.bestEffort
+	if s.closed {
+		s.Unlock()
+		return protocol.ErrClosed
+	}
+	if s.failNoPeers && len(s.pipes) == 0 {
+		s.Unlock()
+		return protocol.ErrNoPeers
+	}
+	pq := s.noPeerQ
+	s.Unlock()
+
+	// Apply timeout if configured and no deadline already set
+	if sendExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, sendExpire)
+			defer cancel()
+		}
+	}
+
+	if bestEffort {
+		select {
+		case s.sendQ <- m:
+		default:
+			m.Free()
+			return nil
+		}
+	} else {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return protocol.ErrSendTimeout
+			}
+			return ctx.Err()
+		case <-pq:
+			return protocol.ErrNoPeers
+		case s.sendQ <- m:
+		case <-s.closeQ:
+			return protocol.ErrClosed
+		}
+	}
+
+	s.Lock()
+	s.cv.Signal()
+	s.Unlock()
+	return nil
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	return s.RecvMsg()
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {

--- a/protocol/xpush/xpush_test.go
+++ b/protocol/xpush/xpush_test.go
@@ -240,10 +240,10 @@ func TestXPushFastFailNoPeerDisconnect(t *testing.T) {
 	ConnectPair(t, s, p)
 
 	go func() {
-		time.Sleep(time.Millisecond*20)
+		time.Sleep(time.Millisecond * 20)
 		MustSucceed(t, p.Close())
 	}()
 
-	MustBeError(t ,s.Send([]byte("three")), mangos.ErrNoPeers)
+	MustBeError(t, s.Send([]byte("three")), mangos.ErrNoPeers)
 	MustSucceed(t, s.Close())
 }

--- a/protocol/xrep/xrep.go
+++ b/protocol/xrep/xrep.go
@@ -17,7 +17,9 @@
 package xrep
 
 import (
+	"context"
 	"encoding/binary"
+	"errors"
 	"sync"
 	"time"
 
@@ -70,7 +72,10 @@ func init() {
 // have headers... the first 4 bytes are the identity of the pipe
 // we should send to.
 func (s *socket) SendMsg(m *protocol.Message) error {
+	return s.SendMsgContext(context.Background(), m)
+}
 
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
 	s.Lock()
 
 	if s.closed {
@@ -88,55 +93,87 @@ func (s *socket) SendMsg(m *protocol.Message) error {
 	hdr := m.Header
 	m.Header = m.Header[4:]
 
+	sendExpire := s.sendExpire
 	bestEffort := s.bestEffort
-	tq := nilQ
 	p, ok := s.pipes[id]
 	if !ok {
 		s.Unlock()
 		m.Free()
 		return nil
 	}
-	if bestEffort {
-		tq = closedQ
-	} else if s.sendExpire > 0 {
-		tq = time.After(s.sendExpire)
-	}
 	s.Unlock()
 
+	// Apply timeout if configured and no deadline already set
+	if sendExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, sendExpire)
+			defer cancel()
+		}
+	}
+
+	if bestEffort {
+		select {
+		case p.sendQ <- m:
+			return nil
+		case <-p.closeQ:
+			m.Free()
+			return nil
+		default:
+			m.Free()
+			return nil
+		}
+	}
+
 	select {
+	case <-ctx.Done():
+		// restore the header
+		m.Header = hdr
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return protocol.ErrSendTimeout
+		}
+		return ctx.Err()
 	case p.sendQ <- m:
 		return nil
 	case <-p.closeQ:
 		// restore the header
 		m.Header = hdr
 		return protocol.ErrClosed
-	case <-tq:
-		if bestEffort {
-			m.Free()
-			return nil
-		}
-		// restore the header
-		m.Header = hdr
-		return protocol.ErrSendTimeout
 	}
 }
 
 func (s *socket) RecvMsg() (*protocol.Message, error) {
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
+	s.Lock()
+	recvExpire := s.recvExpire
+	s.Unlock()
+
+	// Apply timeout if configured and no deadline already set
+	if recvExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, recvExpire)
+			defer cancel()
+		}
+	}
+
 	for {
 		s.Lock()
-		timeQ := nilQ
 		recvQ := s.recvQ
 		sizeQ := s.sizeQ
 		closeQ := s.closeQ
-		if s.recvExpire > 0 {
-			timeQ = time.After(s.recvExpire)
-		}
 		s.Unlock()
 		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, protocol.ErrRecvTimeout
+			}
+			return nil, ctx.Err()
 		case <-closeQ:
 			return nil, protocol.ErrClosed
-		case <-timeQ:
-			return nil, protocol.ErrRecvTimeout
 		case m := <-recvQ:
 			return m, nil
 		case <-sizeQ:

--- a/protocol/xsub/xsub.go
+++ b/protocol/xsub/xsub.go
@@ -17,6 +17,8 @@
 package xsub
 
 import (
+	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -56,25 +58,45 @@ func (s *socket) SendMsg(*protocol.Message) error {
 	return protocol.ErrProtoOp
 }
 
+func (s *socket) SendMsgContext(ctx context.Context, m *protocol.Message) error {
+	return s.SendMsg(m)
+}
+
 func (s *socket) RecvMsg() (*protocol.Message, error) {
+	return s.RecvMsgContext(context.Background())
+}
+
+func (s *socket) RecvMsgContext(ctx context.Context) (*protocol.Message, error) {
 	// For now this uses a simple unified queue for the entire
 	// socket.  Later we can look at moving this to priority queues
 	// based on socket pipes.
-	timeQ := nilQ
+	s.Lock()
+	recvExpire := s.recvExpire
+	s.Unlock()
+
+	// Apply timeout if configured and no deadline already set
+	if recvExpire > 0 {
+		if _, hasDeadline := ctx.Deadline(); !hasDeadline {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, recvExpire)
+			defer cancel()
+		}
+	}
+
 	for {
 		s.Lock()
-		if s.recvExpire > 0 {
-			timeQ = time.After(s.recvExpire)
-		}
 		closeQ := s.closeQ
 		sizeQ := s.sizeQ
 		recvQ := s.recvQ
 		s.Unlock()
 		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return nil, protocol.ErrRecvTimeout
+			}
+			return nil, ctx.Err()
 		case <-closeQ:
 			return nil, protocol.ErrClosed
-		case <-timeQ:
-			return nil, protocol.ErrRecvTimeout
 		case <-sizeQ:
 			continue
 		case m := <-recvQ:

--- a/socket.go
+++ b/socket.go
@@ -14,6 +14,8 @@
 
 package mangos
 
+import "context"
+
 // Socket is the main access handle applications use to access the SP
 // system.  It is an abstraction of an application's "connection" to a
 // messaging topology.  Applications can have more than one Socket open
@@ -44,6 +46,27 @@ type Socket interface {
 	// RecvMsg receives a complete message, including the message header,
 	// which is useful for protocols in raw mode.
 	RecvMsg() (*Message, error)
+
+	// RecvMsgContext receives a complete message, including the message header.
+	// It will block until a message is received, the context is canceled, or
+	// the context deadline expires. When the context is canceled or times out,
+	// the error returned will be ctx.Err().
+	RecvMsgContext(context.Context) (*Message, error)
+
+	// RecvContext receives a complete message. It will block until a message
+	// is received, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	RecvContext(context.Context) ([]byte, error)
+
+	// SendMsgContext sends a message. It will block until the message can be
+	// queued, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	SendMsgContext(context.Context, *Message) error
+
+	// SendContext sends a message. It will block until the message can be
+	// queued, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	SendContext(context.Context, []byte) error
 
 	// Dial connects a remote endpoint to the Socket.  The function
 	// returns immediately, and an asynchronous goroutine is started to
@@ -118,4 +141,25 @@ type Context interface {
 	// RecvMsg receives a complete message, including the message header,
 	// which is useful for protocols in raw mode.
 	RecvMsg() (*Message, error)
+
+	// RecvMsgContext receives a complete message, including the message header.
+	// It will block until a message is received, the context is canceled, or
+	// the context deadline expires. When the context is canceled or times out,
+	// the error returned will be ctx.Err().
+	RecvMsgContext(context.Context) (*Message, error)
+
+	// RecvContext receives a complete message. It will block until a message
+	// is received, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	RecvContext(context.Context) ([]byte, error)
+
+	// SendMsgContext sends a message. It will block until the message can be
+	// queued, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	SendMsgContext(context.Context, *Message) error
+
+	// SendContext sends a message. It will block until the message can be
+	// queued, the context is canceled, or the context deadline expires.
+	// When the context is canceled or times out, the error returned will be ctx.Err().
+	SendContext(context.Context, []byte) error
 }

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -8,8 +8,8 @@ import (
 	"go.nanomsg.org/mangos/v3"
 	"go.nanomsg.org/mangos/v3/protocol/pull"
 	"go.nanomsg.org/mangos/v3/protocol/push"
-	"go.nanomsg.org/mangos/v3/protocol/req"
 	"go.nanomsg.org/mangos/v3/protocol/rep"
+	"go.nanomsg.org/mangos/v3/protocol/req"
 	_ "go.nanomsg.org/mangos/v3/transport/inproc"
 )
 

--- a/test/context_test.go
+++ b/test/context_test.go
@@ -1,0 +1,184 @@
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.nanomsg.org/mangos/v3"
+	"go.nanomsg.org/mangos/v3/protocol/pull"
+	"go.nanomsg.org/mangos/v3/protocol/push"
+	"go.nanomsg.org/mangos/v3/protocol/req"
+	"go.nanomsg.org/mangos/v3/protocol/rep"
+	_ "go.nanomsg.org/mangos/v3/transport/inproc"
+)
+
+func TestRecvMsgContextTimeout(t *testing.T) {
+	pullSock, err := pull.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket: %v", err)
+	}
+	defer pullSock.Close()
+
+	if err := pullSock.Listen("inproc://test_context_timeout"); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Create a context with a short timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	// Try to receive - should timeout
+	start := time.Now()
+	_, err = pullSock.RecvMsgContext(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected timeout error, got nil")
+	}
+
+	if elapsed < 40*time.Millisecond || elapsed > 200*time.Millisecond {
+		t.Fatalf("Expected timeout around 50ms, got %v", elapsed)
+	}
+
+	// Verify we get the protocol timeout error for backwards compatibility
+	if err != mangos.ErrRecvTimeout {
+		t.Fatalf("Expected ErrRecvTimeout, got %v", err)
+	}
+}
+
+func TestRecvMsgContextCancellation(t *testing.T) {
+	pullSock, err := pull.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket: %v", err)
+	}
+	defer pullSock.Close()
+
+	if err := pullSock.Listen("inproc://test_context_cancel"); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	// Create a cancellable context
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Cancel after a short delay
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+	}()
+
+	// Try to receive - should be cancelled
+	start := time.Now()
+	_, err = pullSock.RecvMsgContext(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("Expected cancellation error, got nil")
+	}
+
+	if elapsed < 40*time.Millisecond || elapsed > 200*time.Millisecond {
+		t.Fatalf("Expected cancellation around 50ms, got %v", elapsed)
+	}
+
+	if err != context.Canceled {
+		t.Fatalf("Expected context.Canceled, got %v", err)
+	}
+}
+
+func TestContextWithMessage(t *testing.T) {
+	pushSock, err := push.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket push: %v", err)
+	}
+	defer pushSock.Close()
+
+	pullSock, err := pull.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket pull: %v", err)
+	}
+	defer pullSock.Close()
+
+	if err := pullSock.Listen("inproc://test_context_msg"); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	if err := pushSock.Dial("inproc://test_context_msg"); err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond) // Let connection establish
+
+	// Send a message
+	ctx := context.Background()
+	msg := []byte("hello context")
+	if err := pushSock.SendContext(ctx, msg); err != nil {
+		t.Fatalf("SendContext: %v", err)
+	}
+
+	// Receive with context
+	received, err := pullSock.RecvContext(ctx)
+	if err != nil {
+		t.Fatalf("RecvContext: %v", err)
+	}
+
+	if string(received) != string(msg) {
+		t.Fatalf("Expected %q, got %q", msg, received)
+	}
+}
+
+func TestReqRepWithContext(t *testing.T) {
+	reqSock, err := req.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket req: %v", err)
+	}
+	defer reqSock.Close()
+
+	repSock, err := rep.NewSocket()
+	if err != nil {
+		t.Fatalf("NewSocket rep: %v", err)
+	}
+	defer repSock.Close()
+
+	if err := repSock.Listen("inproc://test_reqrep_context"); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+
+	if err := reqSock.Dial("inproc://test_reqrep_context"); err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond) // Let connection establish
+
+	// Send request with context
+	ctx := context.Background()
+	request := []byte("ping")
+	if err := reqSock.SendContext(ctx, request); err != nil {
+		t.Fatalf("SendContext: %v", err)
+	}
+
+	// Receive request
+	received, err := repSock.RecvContext(ctx)
+	if err != nil {
+		t.Fatalf("RecvContext req: %v", err)
+	}
+
+	if string(received) != string(request) {
+		t.Fatalf("Expected %q, got %q", request, received)
+	}
+
+	// Send reply
+	reply := []byte("pong")
+	if err := repSock.SendContext(ctx, reply); err != nil {
+		t.Fatalf("SendContext reply: %v", err)
+	}
+
+	// Receive reply
+	receivedReply, err := reqSock.RecvContext(ctx)
+	if err != nil {
+		t.Fatalf("RecvContext reply: %v", err)
+	}
+
+	if string(receivedReply) != string(reply) {
+		t.Fatalf("Expected %q, got %q", reply, receivedReply)
+	}
+}

--- a/test/scale_test.go
+++ b/test/scale_test.go
@@ -1,4 +1,6 @@
+//go:build !race
 // +build !race
+
 // Copyright 2018 The Mangos Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/transport/ipc/ipc_options.go
+++ b/transport/ipc/ipc_options.go
@@ -54,4 +54,3 @@ const (
 	// Listener is started.
 	OptionOutputBufferSize = "WIN-IPC-OUTPUT-BUFFER-SIZE"
 )
-

--- a/transport/ipc/ipc_test.go
+++ b/transport/ipc/ipc_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !nacl && !plan9 && !wasm
 // +build !nacl,!plan9,!wasm
 
 package ipc

--- a/transport/ipc/ipc_unix.go
+++ b/transport/ipc/ipc_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !plan9 && !js
 // +build !windows,!plan9,!js
 
 // Copyright 2021 The Mangos Authors

--- a/transport/ipc/ipc_unix_test.go
+++ b/transport/ipc/ipc_unix_test.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//go:build !plan9 && !windows && !js
 // +build !plan9,!windows,!js
 
 package ipc
@@ -205,5 +206,5 @@ func TestIpcListenerOptions(t *testing.T) {
 	MustSucceed(t, l.Listen())
 	i, e := os.Stat(strings.TrimPrefix(addr, "ipc://"))
 	MustSucceed(t, e)
-	MustBeTrue(t, i.Mode() & os.ModePerm == 0642)
+	MustBeTrue(t, i.Mode()&os.ModePerm == 0642)
 }


### PR DESCRIPTION
## Rationale
Closes #215 and fixes a double lock bug.

> [!NOTE]
> A number of files were updated due to running `go fmt`. Happy to revert those and submit as a separate PR.